### PR TITLE
test(smcp-computer): AS-40 FastMCP skill 可注册形状 UAT + gated 集成测试覆盖

### DIFF
--- a/.claude/skills/UAT/resources/scenarios/mcp-fastmcp-skill.md
+++ b/.claude/skills/UAT/resources/scenarios/mcp-fastmcp-skill.md
@@ -1,0 +1,67 @@
+# 场景：mcp-fastmcp-skill（Rust SDK）
+
+## 测试目标
+
+验证当通用 / FastMCP-style MCP provider 以 **`smcp-computer 0.2.2` 可注册的形状**暴露 skill 资源时，
+经 `restage_mcp_skills` 能被注册为 MCP skill 并被 `computer.get_skills()` 收集。
+
+> 背景（AS-40 / comment 13849）：FastMCP **默认** Provider 暴露的裸 `skill://<name>/SKILL.md`
+> （无 `_meta.source`、技能名在 host 段）**当前不会**被 `restage_mcp_skills` 注册——这属于 provider
+> 侧适配范畴（SDK 暂不放宽兼容）。可注册形状要求 provider 以 `_meta.source = "resources"` 的 **skill 根**
+> + 其下子资源（至少 `SKILL.md`）暴露。本场景覆盖「provider 已适配后」的可注册形状。
+
+## 类型
+
+MCP / runtime-boot — **非 CLI-only**。
+
+> ⚠️ CLI 局限：`smcp-computer` CLI 的 MCP skill staging 仅在 `boot_up` 触发，而 MCP server 的批准/连接
+> 发生在 boot **之后**，故 `skill list --source mcp` 在 CLI 流程中观测不到 live MCP skill。可注册性的
+> 自动化验证落在 gated Rust 集成测试（boot → 连接 → restage → `get_skills`）。
+
+## 可注册的资源形状（provider 暴露）
+
+```
+skill://fastmcp-demo/root              _meta = { "source": "resources" }   ← skill 根
+skill://fastmcp-demo/root/SKILL.md     ← 入口（YAML frontmatter，name=fastmcp-demo）
+skill://fastmcp-demo/root/reference.md ← supporting file（resources 模式子资源）
+```
+
+- `_meta.source=resources` 必须挂在 **skill 根 resource** 上，不能直接挂在 `.../SKILL.md`。
+- 根 URI 下须至少有 `SKILL.md` 子资源。
+- 注册结果：`name = mcp:<server>:<frontmatter.name>`、`source = mcp:<server>`、`uri = <root URI>`、
+  物化进 `mcp/<server>/<frontmatter.name>/`。
+
+## 种子 / Seed
+
+- MCP server fixture（可注册形状）：`tests/fastmcp-skill-server/index.js`（项目根，最小 stdio MCP server，
+  `resources/list` + `resources/read`）。亦经 `seeds/mcp/fastmcp-skill-server/README.md` 索引。
+
+## 测试用例
+
+### MF-01: FastMCP（resources-mode 形状）skill 被注册并可发现
+
+- **优先级**: P0 / **类型**: gated 集成测试（需 Node.js）
+- **步骤**:
+  ```bash
+  cargo test --package smcp-computer --test fastmcp_skills_integration -- --ignored
+  ```
+- **预期结果**（已对照实际输出，current SDK 直接通过、无需改码）:
+  - 退出码 0，1 passed
+  - `restage_mcp_skills` 返回含 `mcp:fastmcp-skill-test:fastmcp-demo`
+  - `get_skills()` 含该 skill：`source=mcp:fastmcp-skill-test`、`uri=skill://fastmcp-demo/root`、
+    `description` 来自 SKILL.md frontmatter
+  - runtime skill home 落盘 `mcp/fastmcp-skill-test/fastmcp-demo/{SKILL.md,reference.md}`
+
+### MF-02（负向，文档化）: 裸 `skill://<name>/SKILL.md`（无 _meta.source）不注册
+
+- **优先级**: P1 / **状态**: 现状契约（SDK 暂不兼容裸 FastMCP 布局）
+- **说明**: 若 provider 仅暴露 `skill://fastmcp-demo/SKILL.md`（无 `_meta.source`、无 root 子资源），
+  `restage_mcp_skills` 不会注册该 skill；这是预期现状，由 provider 侧改为 MF-01 形状解决，非 SDK bug。
+
+## 清理
+
+集成测试用 `TempDir`，自动清理；无外部副作用。
+
+## 日志收集
+
+`cargo test ... -- --ignored --nocapture` 保存 stdout；失败时附 `RUST_LOG=smcp_computer=debug` 重跑。

--- a/.claude/skills/UAT/resources/seeds/mcp/fastmcp-skill-server/README.md
+++ b/.claude/skills/UAT/resources/seeds/mcp/fastmcp-skill-server/README.md
@@ -1,0 +1,30 @@
+# Seed: mcp/fastmcp-skill-server
+
+FastMCP-style skill MCP server 种子（场景 `mcp-fastmcp-skill`）。
+
+## 项目上下文 / MCP skill staging 特有
+
+最小 stdio MCP server，暴露 `smcp-computer 0.2.2` **可注册形状**的 FastMCP-style skill 资源：
+`_meta.source = "resources"` 的 skill 根 `skill://fastmcp-demo/root` + 子资源 `.../root/SKILL.md`、
+`.../root/reference.md`。用于验证 `restage_mcp_skills` → `get_skills()` 收集 MCP skill。
+
+## 规范实现（单一真源）
+
+种子脚本即集成测试 fixture：
+
+```
+tests/fastmcp-skill-server/index.js   （项目根）
+```
+
+不在此处复制，避免漂移。该 fixture 由 gated 集成测试
+`crates/smcp-computer/tests/fastmcp_skills_integration.rs` 与本场景共用。
+
+## 运行（验证可注册性）
+
+```bash
+cargo test --package smcp-computer --test fastmcp_skills_integration -- --ignored
+```
+
+预期：注册 `mcp:fastmcp-skill-test:fastmcp-demo`，物化 `mcp/fastmcp-skill-test/fastmcp-demo/{SKILL.md,reference.md}`。
+
+详见 `../../scenarios/mcp-fastmcp-skill.md`。

--- a/crates/smcp-computer/tests/fastmcp_skills_integration.rs
+++ b/crates/smcp-computer/tests/fastmcp_skills_integration.rs
@@ -1,0 +1,103 @@
+//! AS-40 UAT/集成：真实 stdio MCP server 暴露「可注册形状」的 FastMCP-style skill → `computer.get_skills()`。
+//!
+//! 验证 `smcp-computer 0.2.2` 现状能力（**不改 SDK**）：当 provider 以 `_meta.source = "resources"` 的
+//! skill 根 + 子资源（`skill://<name>/root/SKILL.md` …）暴露 FastMCP skill 时，经 `boot_up` → 连接 →
+//! `restage_mcp_skills` 后，`get_skills()` 能收集到该 MCP skill（对齐 AS-40 comment 13849 的本地验证）。
+//!
+//! 注：FastMCP **默认** Provider 的裸 `skill://<name>/SKILL.md`（无 `_meta.source`）当前不会被注册——
+//! 那是 provider 侧适配范畴，本测试覆盖的是适配后的可注册形状。
+//!
+//! 需要 Node.js（gated）。运行：
+//! ```
+//! cargo test --package smcp-computer --test fastmcp_skills_integration -- --ignored
+//! ```
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use smcp_computer::{
+    computer::{Computer, SilentSession},
+    mcp_clients::model::{MCPServerConfig, StdioServerConfig, StdioServerParameters},
+};
+use tempfile::TempDir;
+
+/// FastMCP-style skill stdio MCP server fixture（相对 workspace 根）。
+fn fastmcp_server_path() -> String {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    format!("{}/../../tests/fastmcp-skill-server/index.js", manifest_dir)
+}
+
+#[tokio::test]
+#[ignore] // Requires Node.js
+async fn test_get_skills_collects_fastmcp_resources_mode_skill() {
+    let td = TempDir::new().unwrap();
+    let computer = Computer::new(
+        "computer",
+        SilentSession::new("session"),
+        None,
+        None,
+        true,
+        true,
+    )
+    .with_skill_home(td.path().join("skills"))
+    .with_blob_cache_root(td.path().join("blob"));
+    // 先 boot（解析 skill_home / 装配子系统）——未 boot 时 restage 直接返回空（AS-40 comment）。
+    computer.boot_up().await.expect("boot_up");
+
+    // 连接真实 stdio MCP server（暴露 _meta.source=resources 的 skill 根 + 子资源）。
+    let server = MCPServerConfig::Stdio(StdioServerConfig {
+        env_file: None,
+        name: "fastmcp-skill-test".to_string(),
+        disabled: false,
+        forbidden_tools: vec![],
+        tool_meta: HashMap::new(),
+        default_tool_meta: None,
+        vrl: None,
+        server_parameters: StdioServerParameters {
+            command: "node".to_string(),
+            args: vec![fastmcp_server_path()],
+            env: HashMap::new(),
+            cwd: None,
+        },
+    });
+    computer
+        .add_or_update_server(server)
+        .await
+        .expect("add fastmcp server");
+    // 显式连接（测试 Computer 不依赖 manager auto_connect）→ 激活 client 才能枚举 skill:// 资源。
+    computer
+        .start_mcp_client("fastmcp-skill-test")
+        .await
+        .expect("connect fastmcp server");
+
+    // 全量重物化：识别 resources-mode skill 根并注册。
+    let registered = computer.restage_mcp_skills(None).await;
+    assert!(
+        registered.contains(&"mcp:fastmcp-skill-test:fastmcp-demo".to_string()),
+        "expected FastMCP skill registered, got: {registered:?}"
+    );
+
+    // get_skills 收集到该 skill，字段与既有 mcp 源规则一致。
+    let skills = computer.get_skills().await;
+    let demo = skills
+        .iter()
+        .find(|s| s.name == "mcp:fastmcp-skill-test:fastmcp-demo")
+        .unwrap_or_else(|| panic!("FastMCP skill not in get_skills, got: {skills:?}"));
+    assert_eq!(demo.source, "mcp:fastmcp-skill-test");
+    assert_eq!(
+        demo.description,
+        "A FastMCP-style demo skill registered via resources mode"
+    );
+    assert_eq!(demo.uri.as_deref(), Some("skill://fastmcp-demo/root"));
+
+    // 物化进统一 runtime skill home：SKILL.md + resources-mode 子资源 reference.md 都落盘。
+    let path = Path::new(&demo.path);
+    assert!(path.ends_with("mcp/fastmcp-skill-test/fastmcp-demo"));
+    assert!(path.join("SKILL.md").is_file(), "SKILL.md materialized");
+    assert!(
+        path.join("reference.md").is_file(),
+        "resources-mode sub-resource materialized"
+    );
+
+    computer.shutdown().await.ok();
+}

--- a/tests/fastmcp-skill-server/index.js
+++ b/tests/fastmcp-skill-server/index.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * FastMCP-style skill MCP server fixture（AS-40 UAT / 集成测试）。
+ * FastMCP-style skill MCP server fixture (AS-40 UAT / integration test).
+ *
+ * 暴露 **`smcp-computer 0.2.2` 当前可注册的形状**（见 AS-40 comment 13849）：
+ * 一个带 `_meta.source = "resources"` 的 **skill 根 resource** + 其下子资源（至少含 `SKILL.md`）：
+ *
+ *   skill://fastmcp-demo/root              _meta={ "source": "resources" }   ← skill 根
+ *   skill://fastmcp-demo/root/SKILL.md     ← 入口（YAML frontmatter，name=fastmcp-demo）
+ *   skill://fastmcp-demo/root/reference.md ← supporting file（resources 模式子资源）
+ *
+ * 注意：FastMCP **默认** Provider 暴露的 `skill://<name>/SKILL.md`（无 `_meta.source`、技能名在 host 段）
+ * 当前**不会**被 `restage_mcp_skills` 注册——需 provider 侧改用上面这种 `_meta.source=resources` 约定。
+ * 本 fixture 即模拟「provider 已适配后」的可注册形状。
+ *
+ * 帧格式：换行分隔 JSON（对齐 rmcp / MCP 2025-03-26）。
+ */
+
+const readline = require("readline");
+
+const SERVER_INFO = { name: "fastmcp-skill-server", version: "1.0.0" };
+
+const SKILL_MD =
+  "---\n" +
+  "name: fastmcp-demo\n" +
+  "description: A FastMCP-style demo skill registered via resources mode\n" +
+  "license: MIT\n" +
+  "---\n" +
+  "# FastMCP Demo Skill\n\nEntry SKILL.md body.\n";
+
+const REFERENCE_MD = "# Reference\n\nSupporting reference content (resources-mode sub-resource).\n";
+
+// skill 根带 _meta.source=resources；子资源在 root URI 之下。
+const RESOURCES = [
+  {
+    uri: "skill://fastmcp-demo/root",
+    name: "fastmcp-demo skill root",
+    _meta: { source: "resources" },
+  },
+  { uri: "skill://fastmcp-demo/root/SKILL.md", name: "SKILL.md", mimeType: "text/markdown" },
+  { uri: "skill://fastmcp-demo/root/reference.md", name: "reference.md", mimeType: "text/markdown" },
+];
+
+const RESOURCE_CONTENTS = {
+  "skill://fastmcp-demo/root": "",
+  "skill://fastmcp-demo/root/SKILL.md": SKILL_MD,
+  "skill://fastmcp-demo/root/reference.md": REFERENCE_MD,
+};
+
+function ok(id, result) {
+  return { jsonrpc: "2.0", id, result };
+}
+function err(id, code, message) {
+  return { jsonrpc: "2.0", id, error: { code, message } };
+}
+function writeResponse(resp) {
+  if (resp !== null && resp !== undefined) {
+    process.stdout.write(JSON.stringify(resp) + "\n");
+  }
+}
+
+function handleRequest(request) {
+  const { id, method, params } = request;
+  switch (method) {
+    case "initialize":
+      return ok(id, {
+        protocolVersion: "2025-03-26",
+        capabilities: { resources: { subscribe: false, listChanged: false } },
+        serverInfo: SERVER_INFO,
+      });
+    case "notifications/initialized":
+      return null;
+    case "tools/list":
+      return ok(id, { tools: [] });
+    case "resources/list":
+      return ok(id, { resources: RESOURCES });
+    case "resources/read": {
+      const uri = params && params.uri;
+      const content = RESOURCE_CONTENTS[uri];
+      if (content !== undefined) {
+        return ok(id, { contents: [{ uri, mimeType: "text/markdown", text: content }] });
+      }
+      return err(id, -32602, `Resource not found: ${uri}`);
+    }
+    default:
+      return err(id, -32601, `Method not found: ${method}`);
+  }
+}
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  let request;
+  try {
+    request = JSON.parse(trimmed);
+  } catch (e) {
+    return;
+  }
+  writeResponse(handleRequest(request));
+});


### PR DESCRIPTION
## 背景

AS-40 原始 story 要求 SDK 识别 FastMCP 默认 Provider 的裸 `skill://<name>/SKILL.md` 布局。经 [AS-40 comment 13849](https://turingfocus.atlassian.net/browse/AS-40?focusedCommentId=13849) 本地验证：FastMCP-style skill **已能**被 `smcp-computer 0.2.2` 注册，前提是 **provider 以「可注册形状」暴露**——即 `_meta.source = "resources"` 的 skill 根 resource + 其下子资源（至少 `SKILL.md`）。裸 `skill://<name>/SKILL.md`（无 `_meta.source`、技能名在 host 段）属 provider 侧适配范畴，SDK 暂不放宽兼容。

故本 PR **不改 SDK 代码（零 src 改动）**，只**新增测试 / UAT 覆盖**该可注册场景。

## 改动（仅新增 4 文件）

| 文件 | 说明 |
|------|------|
| `tests/fastmcp-skill-server/index.js` | 最小 stdio MCP server fixture，暴露可注册形状（`_meta.source=resources` 根 + `SKILL.md`/`reference.md` 子资源） |
| `crates/smcp-computer/tests/fastmcp_skills_integration.rs` | gated 集成测试（需 Node + `--ignored`）：boot → 连接 → `restage_mcp_skills` → `get_skills` 断言收集到 `mcp:fastmcp-skill-test:fastmcp-demo` + 物化 `SKILL.md`/`reference.md` |
| `.claude/skills/UAT/resources/scenarios/mcp-fastmcp-skill.md` | UAT 场景：MF-01 可注册形状 / MF-02 裸布局不注册的现状契约 + CLI 局限说明 |
| `.claude/skills/UAT/resources/seeds/mcp/fastmcp-skill-server/README.md` | UAT seed 索引（单一真源指向 tests/ fixture） |

## 关键发现

CLI/tmux UAT **无法观测** live MCP skill 注册——`restage_mcp_skills` 仅在 `boot_up` 触发，而 MCP server 的批准/连接发生在 boot **之后**。故可注册性的自动化验证落在 gated Rust 集成测试。

## 验证

```
cargo test --package smcp-computer --test fastmcp_skills_integration -- --ignored
```
→ **1 passed**（current SDK 无需改码即通过）。新测试 fmt-clean、clippy 无告警、`node --check` 通过。

Refs: AS-40

🤖 Generated with [Claude Code](https://claude.com/claude-code)