### PR TITLE
fix(computer): redact marketplace git credentials

### DIFF
--- a/crates/smcp-computer/src/cli/commands/marketplace.rs
+++ b/crates/smcp-computer/src/cli/commands/marketplace.rs
@@ -33,6 +33,9 @@ use crate::settings::lifecycle::{
     remove_marketplace, resolve_marketplace_identity, AddMarketplaceParams, GovernanceError,
     MarketplaceRefreshRow, MarketplaceRemoveOutcome, RefreshStatus, RemoveMarketplaceParams,
 };
+use crate::settings::redaction::{
+    git_url_for_display, redact_git_urls_in_text, untrusted_name_for_display,
+};
 use crate::settings::schema::FIELD_TRUSTED_MARKETPLACES;
 use crate::settings::scope::{
     apply_write, load_settings_file, user_settings_path, EnvMap, WriteValue,
@@ -53,15 +56,77 @@ fn map_store_err(e: SettingsStoreError) -> std::io::Error {
     std::io::Error::other(e.to_string())
 }
 
+/// 身份解析错误的 CLI 文案。保持纯函数，使终端文本与 JSON `error` 字段共用同一安全边界。
+fn identity_error_message(error: &GovernanceError) -> String {
+    match error {
+        GovernanceError::InvalidUrl(source) => {
+            format!("not a well-formed git url or owner/repo shorthand: {source:?}")
+        }
+        GovernanceError::InvalidName(name) if name.is_empty() => {
+            "cannot derive a valid marketplace name; pass --name with a lowercase kebab-case name"
+                .to_string()
+        }
+        GovernanceError::InvalidName(name) => format!(
+            "invalid marketplace name {name:?}; expected 1-64 lowercase kebab-case characters"
+        ),
+        other => other.to_string(),
+    }
+}
+
+fn unknown_marketplace_message(name: &str) -> String {
+    format!(
+        "unknown marketplace: {:?}",
+        untrusted_name_for_display(name)
+    )
+}
+
+fn unknown_key_message(key: &str) -> String {
+    format!(
+        "unknown key {:?} (only 'auto-update' supported)",
+        untrusted_name_for_display(key)
+    )
+}
+
+fn redact_public_value(value: &Value) -> Value {
+    match value {
+        Value::String(text) => Value::String(redact_git_urls_in_text(text)),
+        Value::Array(items) => Value::Array(items.iter().map(redact_public_value).collect()),
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(key, value)| (redact_git_urls_in_text(key), redact_public_value(value)))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+fn display_plugin_ids(plugin_ids: impl IntoIterator<Item = String>) -> Vec<String> {
+    plugin_ids
+        .into_iter()
+        .map(|plugin_id| untrusted_name_for_display(&plugin_id))
+        .collect()
+}
+
+fn marketplace_list_row(name: &str, rec: &KnownMarketplaceEntry, trusted: bool) -> Value {
+    json!({
+        "name": untrusted_name_for_display(name),
+        "url": display_source_url(rec),
+        "trusted": trusted,
+        "autoUpdate": rec.extra.get("autoUpdate").and_then(Value::as_bool).unwrap_or(false),
+        "lastUpdated": rec.extra.get("lastUpdated").map_or(Value::Null, redact_public_value),
+        "commitSha": rec.extra.get("commitSha").map_or(Value::Null, redact_public_value),
+    })
+}
+
 /// `marketplace remove` 的 JSON 输出 / remove JSON output。
 ///
 /// 抽成纯函数：键名（`removed`/`pruned`/`uninstalledPlugins`/`keptPlugins`）是**跨 SDK 兼容契约**，
 /// 经独立单测锁定 camelCase 防漂移（handler 内联 `json!` 无法在不捕获 stdout 下断言）。
 fn remove_outcome_json(outcome: &MarketplaceRemoveOutcome) -> Value {
     json!({
-        "removed": outcome.name,
-        "pruned": outcome.pruned,
-        "uninstalledPlugins": outcome.uninstalled_plugins,
+        "removed": untrusted_name_for_display(&outcome.name),
+        "pruned": outcome.pruned.iter().map(|name| untrusted_name_for_display(name)).collect::<Vec<_>>(),
+        "uninstalledPlugins": display_plugin_ids(outcome.uninstalled_plugins.clone()),
         "keptPlugins": outcome.kept_plugins,
     })
 }
@@ -72,8 +137,14 @@ fn remove_outcome_json(outcome: &MarketplaceRemoveOutcome) -> Value {
 fn refresh_rows_json(rows: &[MarketplaceRefreshRow]) -> Vec<Value> {
     rows.iter()
         .map(|r| match r.status {
-            RefreshStatus::Missing => json!({ "name": r.name, "status": "missing" }),
-            _ => json!({ "name": r.name, "status": r.status.as_str(), "skills": r.skills }),
+            RefreshStatus::Missing => {
+                json!({ "name": untrusted_name_for_display(&r.name), "status": "missing" })
+            }
+            _ => json!({
+                "name": untrusted_name_for_display(&r.name),
+                "status": r.status.as_str(),
+                "skills": r.skills
+            }),
         })
         .collect()
 }
@@ -85,6 +156,11 @@ fn load_mps(home: &Path, env: Option<&EnvMap>) -> KnownMarketplaces {
 
 fn source_url(rec: &KnownMarketplaceEntry) -> Option<&str> {
     rec.source.get("url").and_then(Value::as_str)
+}
+
+/// 账本 URL 的 CLI 安全展示值；JSON 与文本输出必须共用，避免某种输出模式绕过脱敏。
+fn display_source_url(rec: &KnownMarketplaceEntry) -> Option<String> {
+    source_url(rec).map(git_url_for_display)
 }
 
 fn read_string_array(map: &Map<String, Value>, key: &str) -> Vec<String> {
@@ -172,24 +248,13 @@ pub async fn marketplace_add(
     // 解析身份（归一 URL + 派生/校验名）——信任门与 stage 共用同一身份语义。
     let identity = match resolve_marketplace_identity(git_url, opts.name) {
         Ok(id) => id,
-        Err(GovernanceError::InvalidUrl(u)) => {
-            return err(
-                &format!("not a well-formed git url or owner/repo shorthand: {u:?}"),
-                json_output,
-                EXIT_USER_ERROR,
-            )
-        }
-        Err(GovernanceError::InvalidName(u)) => {
-            return err(
-                &format!("cannot derive a valid marketplace name from {u:?}; pass --name"),
-                json_output,
-                EXIT_USER_ERROR,
-            )
+        Err(e @ GovernanceError::InvalidUrl(_)) | Err(e @ GovernanceError::InvalidName(_)) => {
+            return err(&identity_error_message(&e), json_output, EXIT_USER_ERROR);
         }
         Err(e) => return err(&e.to_string(), json_output, EXIT_USER_ERROR),
     };
     let mp_name = identity.name.clone();
-    let url = identity.url.clone();
+    let display_url = git_url_for_display(&identity.url);
 
     // 重名校验先于信任提示（保留既有时序：重名直接拒、不弹 confirm、不记 trust）。
     if marketplace_name_taken(home, env, &mp_name) {
@@ -207,7 +272,7 @@ pub async fn marketplace_add(
             None => {
                 return err(
                     &format!(
-                        "untrusted marketplace {mp_name:?} ({url}); pass --trust to confirm non-interactively"
+                        "untrusted marketplace {mp_name:?} ({display_url}); pass --trust to confirm non-interactively"
                     ),
                     json_output,
                     EXIT_USER_ERROR,
@@ -215,7 +280,7 @@ pub async fn marketplace_add(
             }
             Some(confirm) => {
                 if !load_trusted(env).iter().any(|n| n == &mp_name)
-                    && !confirm.confirm(&url).await
+                    && !confirm.confirm(&display_url).await
                 {
                     return err("aborted by user (untrusted)", json_output, EXIT_USER_ERROR);
                 }
@@ -249,9 +314,11 @@ pub async fn marketplace_add(
         )),
         Ok(outcome) => {
             if json_output {
-                print_json(
-                    &json!({ "added": outcome.name, "url": outcome.url, "skills": outcome.skills.len() }),
-                );
+                print_json(&json!({
+                    "added": outcome.name,
+                    "url": git_url_for_display(&outcome.url),
+                    "skills": outcome.skills.len()
+                }));
                 return EXIT_OK;
             }
             ok_msg(&format!(
@@ -259,8 +326,8 @@ pub async fn marketplace_add(
                 outcome.skills.len()
             ))
         }
-        Err(GovernanceError::CloneFailed(u)) => err(
-            &format!("clone/refresh failed for {u:?} (see logs)"),
+        Err(GovernanceError::CloneFailed(name)) => err(
+            &format!("clone/refresh failed for marketplace {name:?} (see logs)"),
             json_output,
             EXIT_NETWORK_ERROR,
         ),
@@ -283,16 +350,7 @@ pub fn marketplace_list(home: &Path, env: Option<&EnvMap>, json_output: bool) ->
         let rows: Vec<Value> = mps
             .marketplaces
             .iter()
-            .map(|(nm, rec)| {
-                json!({
-                    "name": nm,
-                    "url": source_url(rec),
-                    "trusted": is_trusted(nm),
-                    "autoUpdate": rec.extra.get("autoUpdate").and_then(Value::as_bool).unwrap_or(false),
-                    "lastUpdated": rec.extra.get("lastUpdated").cloned().unwrap_or(Value::Null),
-                    "commitSha": rec.extra.get("commitSha").cloned().unwrap_or(Value::Null),
-                })
-            })
+            .map(|(nm, rec)| marketplace_list_row(nm, rec, is_trusted(nm)))
             .collect();
         print_json(&json!(rows));
         return EXIT_OK;
@@ -304,12 +362,14 @@ pub fn marketplace_list(home: &Path, env: Option<&EnvMap>, json_output: bool) ->
     }
     println!("Marketplaces:");
     for (nm, rec) in &mps.marketplaces {
-        let url = source_url(rec).unwrap_or("");
+        let display_name = untrusted_name_for_display(nm);
+        let url = display_source_url(rec).unwrap_or_default();
         let sha = rec
             .extra
             .get("commitSha")
             .and_then(Value::as_str)
-            .unwrap_or("");
+            .map(redact_git_urls_in_text)
+            .unwrap_or_default();
         let sha_disp = if sha.is_empty() {
             "—".to_string()
         } else {
@@ -326,7 +386,7 @@ pub fn marketplace_list(home: &Path, env: Option<&EnvMap>, json_output: bool) ->
             "off"
         };
         println!(
-            "  {nm}  ·  {url}  ·  trusted={}  ·  auto-update={auto}  ·  commit={sha_disp}",
+            "  {display_name}  ·  {url}  ·  trusted={}  ·  auto-update={auto}  ·  commit={sha_disp}",
             if is_trusted(nm) { "✓" } else { "—" },
         );
     }
@@ -336,9 +396,10 @@ pub fn marketplace_list(home: &Path, env: Option<&EnvMap>, json_output: bool) ->
 /// marketplace 详情：URL / clone 路径 / commit / plugins[] / auto_update / trusted。
 pub fn marketplace_info(home: &Path, env: Option<&EnvMap>, name: &str, json_output: bool) -> i32 {
     let mps = load_mps(home, env);
+    let display_name = untrusted_name_for_display(name);
     let Some(rec) = mps.marketplaces.get(name) else {
         return err(
-            &format!("unknown marketplace: {name:?}"),
+            &unknown_marketplace_message(name),
             json_output,
             EXIT_USER_ERROR,
         );
@@ -346,29 +407,30 @@ pub fn marketplace_info(home: &Path, env: Option<&EnvMap>, name: &str, json_outp
 
     let installed = load_installed_plugins(Some(home), env).account;
     let suffix = format!("@{name}");
-    let plugins: Vec<String> = installed
-        .plugins
-        .keys()
-        .filter(|pid| pid.ends_with(&suffix))
-        .cloned()
-        .collect();
+    let plugins = display_plugin_ids(
+        installed
+            .plugins
+            .keys()
+            .filter(|pid| pid.ends_with(&suffix))
+            .cloned(),
+    );
     let trusted = load_trusted(env).iter().any(|t| t == name);
 
     let info = json!({
-        "name": name,
-        "url": source_url(rec),
-        "installLocation": rec.extra.get("installLocation").cloned().unwrap_or(Value::Null),
-        "commitSha": rec.extra.get("commitSha").cloned().unwrap_or(Value::Null),
+        "name": display_name.clone(),
+        "url": display_source_url(rec),
+        "installLocation": rec.extra.get("installLocation").map_or(Value::Null, redact_public_value),
+        "commitSha": rec.extra.get("commitSha").map_or(Value::Null, redact_public_value),
         "autoUpdate": rec.extra.get("autoUpdate").and_then(Value::as_bool).unwrap_or(false),
         "trusted": trusted,
-        "lastUpdated": rec.extra.get("lastUpdated").cloned().unwrap_or(Value::Null),
+        "lastUpdated": rec.extra.get("lastUpdated").map_or(Value::Null, redact_public_value),
         "installedPlugins": plugins,
     });
     if json_output {
         print_json(&info);
         return EXIT_OK;
     }
-    println!("Marketplace · {name}");
+    println!("Marketplace · {display_name}");
     for key in [
         "url",
         "installLocation",
@@ -419,16 +481,17 @@ pub async fn marketplace_remove(
     non_plugin_bundle_ids: &std::collections::HashSet<crate::mcp_clients::model::BundleId>,
 ) -> i32 {
     let json_output = opts.json_output;
+    let display_name = untrusted_name_for_display(name);
     // 未知校验先于 confirm（保留既有时序：未知直接拒、不弹 confirm）。
     if !marketplace_name_taken(home, env, name) {
         return err(
-            &format!("unknown marketplace: {name:?}"),
+            &unknown_marketplace_message(name),
             json_output,
             EXIT_USER_ERROR,
         );
     }
     if let Some(confirm) = opts.confirm {
-        if !confirm.confirm(name).await {
+        if !confirm.confirm(&display_name).await {
             return err("aborted by user", json_output, EXIT_USER_ERROR);
         }
     }
@@ -454,7 +517,7 @@ pub async fn marketplace_remove(
     // 无错误处理）——写失败仅告警、**不**把已完成的卸载/prune 级联翻成用户错（destructive 工作已落地）。
     if let Err(e) = revoke_trust(name, env) {
         msg_dim(&format!(
-            "warning: failed to revoke trust for {name:?}: {e}"
+            "warning: failed to revoke trust for {display_name:?}: {e}"
         ));
     }
 
@@ -472,7 +535,7 @@ pub async fn marketplace_remove(
     } else {
         String::new()
     };
-    ok_msg(&format!("removed marketplace {name:?}{detail}"))
+    ok_msg(&format!("removed marketplace {display_name:?}{detail}"))
 }
 
 /// `git pull` 失败则全量重 clone；与缓存 plugin 集合对账 + 失败汇总（§10.4）/ refresh marketplaces。
@@ -498,7 +561,11 @@ pub async fn marketplace_refresh(
             RefreshStatus::Unchanged => "·",
             RefreshStatus::Missing => "✗",
         };
-        println!("  {mark} {}  ({})", r.name, r.status.as_str());
+        println!(
+            "  {mark} {}  ({})",
+            untrusted_name_for_display(&r.name),
+            r.status.as_str()
+        );
     }
     let updated = rows
         .iter()
@@ -524,12 +591,9 @@ pub fn marketplace_set(
     value: &str,
     json_output: bool,
 ) -> i32 {
+    let display_name = untrusted_name_for_display(name);
     if key != "auto-update" {
-        return err(
-            &format!("unknown key {key:?} (only 'auto-update' supported)"),
-            json_output,
-            EXIT_USER_ERROR,
-        );
+        return err(&unknown_key_message(key), json_output, EXIT_USER_ERROR);
     }
     let val = matches!(
         value.trim().to_lowercase().as_str(),
@@ -537,7 +601,7 @@ pub fn marketplace_set(
     );
     if !load_mps(home, env).marketplaces.contains_key(name) {
         return err(
-            &format!("unknown marketplace: {name:?}"),
+            &unknown_marketplace_message(name),
             json_output,
             EXIT_USER_ERROR,
         );
@@ -561,10 +625,10 @@ pub fn marketplace_set(
         );
     }
     if json_output {
-        print_json(&json!({ "name": name, "autoUpdate": val }));
+        print_json(&json!({ "name": display_name, "autoUpdate": val }));
         return EXIT_OK;
     }
-    ok_msg(&format!("{name:?} auto-update set to {val}"))
+    ok_msg(&format!("{display_name:?} auto-update set to {val}"))
 }
 
 #[cfg(test)]
@@ -578,6 +642,7 @@ mod tests {
     struct MockConfirm {
         answer: bool,
         called: std::sync::atomic::AtomicBool,
+        target: std::sync::Mutex<Option<String>>,
     }
 
     impl MockConfirm {
@@ -585,22 +650,170 @@ mod tests {
             Self {
                 answer,
                 called: std::sync::atomic::AtomicBool::new(false),
+                target: std::sync::Mutex::new(None),
             }
         }
         fn was_called(&self) -> bool {
             self.called.load(std::sync::atomic::Ordering::SeqCst)
         }
+        fn target(&self) -> Option<String> {
+            self.target.lock().unwrap().clone()
+        }
     }
 
     #[async_trait]
     impl Confirm for MockConfirm {
-        async fn confirm(&self, _target: &str) -> bool {
+        async fn confirm(&self, target: &str) -> bool {
             self.called.store(true, std::sync::atomic::Ordering::SeqCst);
+            *self.target.lock().unwrap() = Some(target.to_string());
             self.answer
         }
     }
 
     // URL 归一 / 名派生纯函数的单测随实现迁移到 settings::lifecycle（#94），不在此重复。
+
+    #[test]
+    fn identity_error_cli_message_never_echoes_credentialed_url() {
+        const SECRET_URL: &str = "https://cnb:FAKE_TOKEN@example.com/org/repo.git";
+        let error = resolve_marketplace_identity(SECRET_URL, Some("Turingfocus")).unwrap_err();
+        let message = identity_error_message(&error);
+        assert!(message.contains("Turingfocus"));
+        assert!(!message.contains("cnb"));
+        assert!(!message.contains("FAKE_TOKEN"));
+        assert!(!message.contains(SECRET_URL));
+    }
+
+    #[test]
+    fn identity_error_cli_message_redacts_url_embedded_in_explicit_name() {
+        let error = resolve_marketplace_identity(
+            "acme/skills",
+            Some("key=https://user:PW_SECRET@example.com/name"),
+        )
+        .unwrap_err();
+        let message = identity_error_message(&error);
+        assert!(message.contains("key="));
+        for secret in ["user", "PW_SECRET"] {
+            assert!(!message.contains(secret), "{message}");
+        }
+    }
+
+    #[test]
+    fn identity_error_cli_message_for_pathless_url_contains_no_credentials() {
+        let error = resolve_marketplace_identity(
+            "https://user:PW_SECRET@example.com?token=QUERY#FRAGMENT",
+            None,
+        )
+        .unwrap_err();
+        let message = identity_error_message(&error);
+        assert!(message.contains("cannot derive a valid marketplace name"));
+        for secret in ["user", "PW_SECRET", "QUERY", "FRAGMENT"] {
+            assert!(!message.contains(secret), "{message}");
+        }
+    }
+
+    #[test]
+    fn unknown_name_and_key_cli_messages_never_echo_credentials() {
+        for message in [
+            unknown_marketplace_message(
+                "x=https://public.example/a=https://user2:PW_TWO@secret.example/repo.git",
+            ),
+            unknown_marketplace_message(
+                "x=https://example.com/r.git?token=QUERY_QUOTE'LEAK_SECRET",
+            ),
+            unknown_marketplace_message("x=https://alice:PW_ONE'PW_TWO@example.com/repo.git"),
+            unknown_marketplace_message("key=用户@example.com:org/repo.git"),
+            unknown_key_message("https://user:PW_SECRET@example.com/repo.git"),
+        ] {
+            for secret in [
+                "user",
+                "PW_SECRET",
+                "user2",
+                "PW_TWO",
+                "用户",
+                "QUERY_QUOTE",
+                "LEAK_SECRET",
+                "PW_ONE",
+            ] {
+                assert!(!message.contains(secret), "{message}");
+            }
+        }
+    }
+
+    #[test]
+    fn ledger_url_display_is_credential_free_for_text_and_json_paths() {
+        let rec = KnownMarketplaceEntry {
+            source: json!({
+                "type": "git",
+                "url": "https://cnb:FAKE_TOKEN@example.com/org/repo.git?token=QUERY#FRAGMENT"
+            }),
+            extra: Map::new(),
+        };
+        let displayed = display_source_url(&rec).unwrap();
+        assert_eq!(displayed, "https://example.com/org/repo.git");
+        for secret in ["cnb", "FAKE_TOKEN", "QUERY", "FRAGMENT"] {
+            assert!(!displayed.contains(secret));
+        }
+    }
+
+    #[test]
+    fn hand_edited_ledger_identifiers_are_safe_for_text_and_json() {
+        let rec = KnownMarketplaceEntry {
+            source: json!({"type": "git", "url": "https://example.com/repo.git"}),
+            extra: Map::from_iter([
+                (
+                    "commitSha".to_string(),
+                    json!("https://alice:PW_META@example.com/r.git?token=;META_SECRET"),
+                ),
+                (
+                    "lastUpdated".to_string(),
+                    json!({
+                        "x=https://alice:PW_KEY@example.com/r.git": {
+                            "source": "git@secret.example:org/repo.git"
+                        }
+                    }),
+                ),
+            ]),
+        };
+        let row = marketplace_list_row("x=https://alice:PW_NAME@example.com/repo.git", &rec, false);
+        let plugin_ids =
+            display_plugin_ids(["x=https://alice:PW_PLUGIN@example.com/repo.git@safe".to_string()]);
+        let remove = remove_outcome_json(&MarketplaceRemoveOutcome {
+            name: "x=https://alice:PW_REMOVE@example.com/repo.git".to_string(),
+            pruned: vec!["git@secret.example:PW_PRUNED".to_string()],
+            uninstalled_plugins: vec![
+                "x=https://alice:PW_UNINSTALL@example.com/repo.git@safe".to_string()
+            ],
+            kept_plugins: false,
+        });
+        let refresh = refresh_rows_json(&[MarketplaceRefreshRow {
+            name: "x=https://alice:PW_REFRESH@example.com/repo.git".to_string(),
+            status: RefreshStatus::Missing,
+            skills: 0,
+        }]);
+        let rendered = format!(
+            "{}\n{}\n{}\n{}\n{}",
+            serde_json::to_string(&row).unwrap(),
+            row["name"],
+            plugin_ids.join(", "),
+            serde_json::to_string(&remove).unwrap(),
+            serde_json::to_string(&refresh).unwrap(),
+        );
+        for secret in [
+            "alice",
+            "PW_META",
+            "META_SECRET",
+            "PW_KEY",
+            "secret.example",
+            "PW_NAME",
+            "PW_PLUGIN",
+            "PW_REMOVE",
+            "PW_PRUNED",
+            "PW_UNINSTALL",
+            "PW_REFRESH",
+        ] {
+            assert!(!rendered.contains(secret), "{rendered}");
+        }
+    }
 
     #[tokio::test]
     async fn add_non_interactive_requires_trust() {
@@ -811,6 +1024,34 @@ mod tests {
         .await;
         assert_eq!(code, EXIT_USER_ERROR);
         assert!(confirm.was_called());
+        assert!(load_mps(home, Some(&env)).marketplaces.is_empty());
+    }
+
+    #[tokio::test]
+    async fn add_interactive_confirm_receives_credential_free_url() {
+        let dir = tempdir().unwrap();
+        let home = dir.path();
+        let env = test_env(home);
+        let mut registry = SkillRegistry::new();
+        let confirm = MockConfirm::new(false);
+        let code = marketplace_add(
+            &mut registry,
+            home,
+            Some(&env),
+            "https://cnb:FAKE_TOKEN@example.com/org/repo.git?token=QUERY#FRAGMENT",
+            MarketplaceAddOptions {
+                name: Some("valid-name"),
+                confirm: Some(&confirm),
+                json_output: true,
+                ..Default::default()
+            },
+        )
+        .await;
+        assert_eq!(code, EXIT_USER_ERROR);
+        assert_eq!(
+            confirm.target().as_deref(),
+            Some("https://example.com/org/repo.git")
+        );
         assert!(load_mps(home, Some(&env)).marketplaces.is_empty());
     }
 

--- a/crates/smcp-computer/src/computer.rs
+++ b/crates/smcp-computer/src/computer.rs
@@ -849,6 +849,7 @@ impl<S: Session> Computer<S> {
     /// 与 [`ensure_skill_home`](Self::ensure_skill_home) 的区别是**无副作用**：后者会解析并落缓存（且下游
     /// `skill_home()` 会建目录）。只读路径（如 #141 的 CLI 候选表）用本方法——boot 后恒已解析，boot 前
     /// 返回 `None` 而不是凭空造出一个 home。对齐 python `collect_candidates` 读裸 `_skill_home` 的约定。
+    #[cfg(feature = "cli")]
     fn skill_home_opt(&self) -> Option<PathBuf> {
         self.skill_home
             .read()
@@ -1170,6 +1171,7 @@ impl<S: Session> Computer<S> {
     ///
     /// 与 [`non_plugin_declared_bundle_ids`](Self::non_plugin_declared_bundle_ids) 同源同参（同一次
     /// `resolve_snapshot`、同样必须传全 flag/embed 输入），差别只在此处返回 config、那处返回 bundle_id 集。
+    #[cfg(feature = "cli")]
     pub(crate) fn declared_mcp_servers(&self) -> Vec<crate::mcp_clients::model::MCPServerConfig> {
         use crate::settings::config::snapshot::{resolve_snapshot, SnapshotArgs};
         let config_dir = self.config_dir();
@@ -1724,7 +1726,7 @@ impl<S: Session> Computer<S> {
         let servers = self.mcp_servers.read().await;
         let mut validated_servers = Vec::new();
 
-        for (_name, server_config) in servers.iter() {
+        for server_config in servers.values() {
             match self.render_server_config(server_config).await {
                 Ok(validated) => validated_servers.push(validated),
                 Err(e) => {

--- a/crates/smcp-computer/src/governance.rs
+++ b/crates/smcp-computer/src/governance.rs
@@ -37,6 +37,10 @@ use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 
 use crate::settings::config::snapshot::{resolve_snapshot, SnapshotArgs};
+use crate::settings::redaction::{
+    git_url_for_display, redact_git_urls_in_text, untrusted_name_for_display,
+};
+use crate::settings::schema::is_valid_marketplace_name;
 use crate::settings::scope::EnvMap;
 use crate::settings::store::{load_installed_plugins, load_known_marketplaces};
 use crate::skills::frontmatter::parse_skill_frontmatter;
@@ -96,8 +100,40 @@ impl GovernanceDiagnostic {
     fn new(code: &str, message: impl Into<String>) -> Self {
         Self {
             code: code.to_string(),
-            message: message.into(),
+            message: redact_git_urls_in_text(&message.into()),
         }
+    }
+}
+
+fn public_optional_text(value: Option<String>) -> Option<String> {
+    value.map(|text| redact_git_urls_in_text(&text))
+}
+
+fn public_texts(values: impl IntoIterator<Item = String>) -> Vec<String> {
+    values
+        .into_iter()
+        .map(|text| untrusted_name_for_display(&text))
+        .collect()
+}
+
+fn sanitize_declared_capabilities(capabilities: &mut DeclaredCapabilities) {
+    capabilities.version = public_optional_text(capabilities.version.take());
+    capabilities.description = public_optional_text(capabilities.description.take());
+    capabilities.mcp_servers = public_texts(std::mem::take(&mut capabilities.mcp_servers));
+    capabilities.skills = public_texts(std::mem::take(&mut capabilities.skills));
+}
+
+fn sanitize_plugin_snapshot(plugin: &mut PluginSnapshot) {
+    plugin.id = untrusted_name_for_display(&plugin.id);
+    plugin.plugin = untrusted_name_for_display(&plugin.plugin);
+    plugin.marketplace = untrusted_name_for_display(&plugin.marketplace);
+    plugin.name = public_optional_text(plugin.name.take());
+    plugin.version = public_optional_text(plugin.version.take());
+    plugin.install_scope = public_optional_text(plugin.install_scope.take());
+    plugin.install_path = public_optional_text(plugin.install_path.take());
+    plugin.bundled_mcp_servers = public_texts(std::mem::take(&mut plugin.bundled_mcp_servers));
+    if let Some(declared) = &mut plugin.declared {
+        sanitize_declared_capabilities(declared);
     }
 }
 
@@ -441,6 +477,14 @@ pub(crate) fn resolve_governance_snapshot(
                         let Some(pn) = e.get("name").and_then(Value::as_str) else {
                             continue;
                         };
+                        let pn = pn.trim();
+                        if !is_valid_marketplace_name(pn) {
+                            diagnostics.push(GovernanceDiagnostic::new(
+                                "plugin_entry_invalid",
+                                "plugin entry name must be lowercase kebab-case (1-64 characters)",
+                            ));
+                            continue;
+                        }
                         let id = format!("{pn}@{name}");
                         declared_by_id.insert(
                             id.clone(),
@@ -464,19 +508,19 @@ pub(crate) fn resolve_governance_snapshot(
         available_by_mp.insert(name.clone(), available_plugin_ids.clone());
 
         marketplaces.push(MarketplaceSnapshot {
-            name: name.clone(),
-            source_url,
+            name: untrusted_name_for_display(name),
+            source_url: source_url.map(|url| git_url_for_display(&url)),
             trusted: is_trusted,
             blocked: is_blocked,
             strict,
             decision,
-            install_location,
-            commit_sha,
-            last_updated,
+            install_location: public_optional_text(install_location),
+            commit_sha: public_optional_text(commit_sha),
+            last_updated: public_optional_text(last_updated),
             auto_update,
             status,
-            plugin_ids,
-            available_plugin_ids,
+            plugin_ids: public_texts(plugin_ids),
+            available_plugin_ids: public_texts(available_plugin_ids),
             diagnostics,
         });
     }
@@ -617,14 +661,18 @@ pub(crate) fn resolve_governance_snapshot(
     }
 
     plugins.sort_by(|a, b| a.id.cmp(&b.id));
+    let overlay_plugin_ids: Vec<String> = plugins.iter().map(|plugin| plugin.id.clone()).collect();
+    for plugin in &mut plugins {
+        sanitize_plugin_snapshot(plugin);
+    }
 
     // --- revision = 磁盘核心投影摘要（**在填 overlay 之前**计算 → 排除 live 叠加）---
     let revision = compute_revision(&marketplaces, &plugins);
 
     // --- 填 live overlay（不影响已算好的 revision）---
-    for p in &mut plugins {
-        if let Some(skills) = overlay.bundled_skills_by_plugin.get(&p.id) {
-            p.bundled_skills = skills.clone();
+    for (p, raw_id) in plugins.iter_mut().zip(overlay_plugin_ids) {
+        if let Some(skills) = overlay.bundled_skills_by_plugin.get(&raw_id) {
+            p.bundled_skills = public_texts(skills.clone());
         }
         p.materialized_mcp_servers = p
             .bundled_mcp_servers
@@ -1020,6 +1068,131 @@ mod tests {
     }
 
     #[test]
+    fn hand_edited_governance_dto_never_echoes_git_credentials() {
+        let td = TempDir::new().unwrap();
+        let env = xdg_env(&td);
+        let home = td.path().join("home");
+        let catalog = td.path().join("catalog");
+        seed_catalog(
+            &catalog,
+            &["x=https://manifest:PW_PLUGIN@example.com/repo.git"],
+        );
+
+        update_known_marketplaces(
+            |f| {
+                f.account.marketplaces.insert(
+                    "x=https://alice:PW_NAME@secret.example/repo.git".to_string(),
+                    KnownMarketplaceEntry {
+                        source: json!({
+                            "type": "git",
+                            "url": "https://bob:PW_URL@example.com/r.git?token=QUERY#FRAGMENT"
+                        }),
+                        extra: Map::from_iter([
+                            (
+                                "installLocation".to_string(),
+                                json!("/tmp/x=https:/carol:PW_PATH@example.com/repo.git"),
+                            ),
+                            (
+                                "commitSha".to_string(),
+                                json!("https://dave:PW_SHA@example.com/r.git"),
+                            ),
+                            (
+                                "lastUpdated".to_string(),
+                                json!("git@secret.example:PW_UPDATED"),
+                            ),
+                        ]),
+                    },
+                );
+                f.account.marketplaces.insert(
+                    "safe".to_string(),
+                    KnownMarketplaceEntry {
+                        source: json!({"type": "git", "url": "https://example.com/safe.git"}),
+                        extra: Map::from_iter([(
+                            "installLocation".to_string(),
+                            json!(catalog.to_string_lossy()),
+                        )]),
+                    },
+                );
+            },
+            Some(&home),
+            None,
+        )
+        .unwrap();
+        update_installed_plugins_intent(
+            |f| {
+                f.account.installed_plugins.insert("audit@safe".to_string());
+            },
+            Some(&home),
+            None,
+        )
+        .unwrap();
+        update_installed_plugins(
+            |f| {
+                let mut extra = Map::new();
+                extra.insert(
+                    "version".to_string(),
+                    json!("https://eve:PW_VERSION@example.com/r.git"),
+                );
+                f.account.plugins.insert(
+                    "audit@safe".to_string(),
+                    vec![InstalledPluginRecord {
+                        install_path: Some(
+                            "/tmp/x=https:/frank:PW_INSTALL@example.com/repo.git".to_string(),
+                        ),
+                        mcp_servers: vec![],
+                        extra,
+                    }],
+                );
+            },
+            Some(&home),
+            None,
+        )
+        .unwrap();
+
+        let snap = resolve_governance_snapshot(
+            GovernanceArgs {
+                cwd: Some(td.path()),
+                env: Some(&env),
+                home: Some(&home),
+                managed_mcp_path: Some(&no_managed(&td)),
+                ..Default::default()
+            },
+            &GovernanceRuntimeOverlay::default(),
+        );
+        let rendered = format!("{snap:?}\n{}", serde_json::to_string(&snap).unwrap());
+        for secret in [
+            "alice",
+            "PW_NAME",
+            "bob",
+            "PW_URL",
+            "QUERY",
+            "FRAGMENT",
+            "carol",
+            "PW_PATH",
+            "dave",
+            "PW_SHA",
+            "PW_UPDATED",
+            "PW_PLUGIN",
+            "eve",
+            "PW_VERSION",
+            "frank",
+            "PW_INSTALL",
+        ] {
+            assert!(!rendered.contains(secret), "{rendered}");
+        }
+        let safe = snap
+            .marketplaces
+            .iter()
+            .find(|marketplace| marketplace.name == "safe")
+            .unwrap();
+        assert!(safe.available_plugin_ids.is_empty());
+        assert!(safe
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "plugin_entry_invalid"));
+    }
+
+    #[test]
     fn revision_stable_and_excludes_overlay() {
         let td = TempDir::new().unwrap();
         let env = xdg_env(&td);
@@ -1200,6 +1373,57 @@ mod tests {
         let (declared, diags, root_broken) =
             probe_declared_capabilities(td.path(), "./plugins", "x", &entry);
         assert!(declared.is_none() && diags.is_empty() && !root_broken);
+    }
+
+    #[test]
+    fn probe_malformed_source_diagnostic_never_echoes_url_credentials() {
+        let td = TempDir::new().unwrap();
+        for source in [
+            json!({
+                "source": "url",
+                "url": "ftp://cnb:FAKE_TOKEN@example.com/org/repo.git?token=QUERY#FRAGMENT"
+            }),
+            json!("key=https://cnb:FAKE_TOKEN@example.com/org/repo.git"),
+            json!("key=git@example.com:org/repo.git"),
+            json!("x=https://public.example/a=https://user2:PW_TWO@secret.example/repo.git"),
+            json!("key=用户@example.com:org/repo.git"),
+            json!("x=https://example.com/r.git?token=;QUERY_SECRET"),
+            json!("x=https://example.com/r.git?token=QUERY_QUOTE'LEAK_SECRET"),
+            json!("x=https://alice:PW_ONE'PW_TWO@example.com/repo.git"),
+            json!("x=alice@my_host:org/repo.git"),
+            json!("x=用户@例子.公司:org/repo.git"),
+        ] {
+            let entry = obj(json!({"name": "x", "source": source}));
+            let (declared, diags, root_broken) =
+                probe_declared_capabilities(td.path(), "./plugins", "x", &entry);
+            assert!(declared.is_none() && !root_broken);
+            let diagnostic = diags
+                .iter()
+                .find(|d| d.code == "plugin_source_unresolved")
+                .expect("malformed source must produce a governance diagnostic");
+            let rendered = format!(
+                "{}\n{diagnostic:?}\n{}",
+                diagnostic.message,
+                serde_json::to_string(diagnostic).unwrap()
+            );
+            for secret in [
+                "cnb",
+                "FAKE_TOKEN",
+                "QUERY",
+                "FRAGMENT",
+                "git@example.com",
+                "user2",
+                "PW_TWO",
+                "用户",
+                "QUERY_SECRET",
+                "QUERY_QUOTE",
+                "LEAK_SECRET",
+                "PW_ONE",
+                "alice",
+            ] {
+                assert!(!rendered.contains(secret), "{rendered}");
+            }
+        }
     }
 
     #[test]

--- a/crates/smcp-computer/src/settings/config/portability.rs
+++ b/crates/smcp-computer/src/settings/config/portability.rs
@@ -31,6 +31,8 @@ use std::sync::LazyLock;
 use regex::Regex;
 use serde_json::{Map, Value};
 
+use crate::settings::redaction::url_with_redacted_userinfo;
+
 use super::crud::{load_project_config_doc, save_config, ConfigCrudError, ProjectConfigDoc};
 use super::validate::{validate_config, ValidationReport};
 
@@ -134,31 +136,10 @@ fn redact_string_map_values(params: &mut Map<String, Value>, field: &str) {
 /// 只动 authority 段的 userinfo（`@` 前、authority 内）——host/path/query 不动（query token 属声明外未覆盖面）。
 fn redact_url_userinfo(params: &mut Map<String, Value>) {
     if let Some(Value::String(url)) = params.get_mut("url") {
-        if let Some(redacted) = url_with_redacted_userinfo(url) {
+        if let Some(redacted) = url_with_redacted_userinfo(url, REDACTED_PLACEHOLDER) {
             *url = redacted;
         }
     }
-}
-
-/// 若 `url` 的 authority 段含非空 userinfo → 返回抹去 userinfo 的新串；否则 `None`（不改）。
-fn url_with_redacted_userinfo(url: &str) -> Option<String> {
-    let after_scheme = url.find("://")? + 3;
-    // authority 终止于首个 '/'（path 起点）或串尾。
-    let authority_end = url[after_scheme..]
-        .find('/')
-        .map(|i| after_scheme + i)
-        .unwrap_or(url.len());
-    let at_rel = url[after_scheme..authority_end].find('@')?;
-    let at = after_scheme + at_rel;
-    if at <= after_scheme {
-        return None; // userinfo 为空（`scheme://@host`）→ 无 secret。
-    }
-    Some(format!(
-        "{}{}{}",
-        &url[..after_scheme],
-        REDACTED_PLACEHOLDER,
-        &url[at..]
-    ))
 }
 
 /// **分段脱敏**一个字符串：逐字保留合法闭合且可识别（`input:`/`env:`）的占位符引用，其余**每段字面**抹为哨兵。

--- a/crates/smcp-computer/src/settings/lifecycle.rs
+++ b/crates/smcp-computer/src/settings/lifecycle.rs
@@ -29,11 +29,15 @@
 use std::path::Path;
 
 use serde_json::{json, Map, Value};
+use url::Url;
 
 use crate::settings::installer::{
     uninstall_plugin, McpInstallHooks, PluginInstallError, UninstallOptions,
 };
 use crate::settings::reconciler::{prune_marketplaces, SkillGovernanceStore};
+use crate::settings::redaction::{
+    git_source_for_error, redact_git_urls_in_text, untrusted_name_for_display,
+};
 use crate::settings::scope::EnvMap;
 use crate::settings::store::{
     load_installed_plugins, load_known_marketplaces, update_known_marketplaces,
@@ -51,14 +55,15 @@ use crate::skills::{
 /// marketplace/plugin 生命周期编排失败（**结构化、非退出码**）/ Structured governance lifecycle failure。
 ///
 /// CLI handler 据各变体映射退出码（`CloneFailed` → 网络错 2，其余 → 用户错 1）+ 拼装用户面文案；GUI/Tauri
-/// client 直接消费结构化变体。携带的数据（git_url / name）足以让消费方自定义文案。
+/// client 直接消费结构化变体。所有字符串载荷均可安全进入公开 `Debug` / `Display`：URL 型输入先脱敏，
+/// 名称错误只携名称，clone 错误只携 marketplace 名。
 #[derive(Debug, thiserror::Error)]
 pub enum GovernanceError {
     /// 既非合法 git URL 也非 `owner/repo` 简写 / not a well-formed git URL or `owner/repo` shorthand。
     #[error("not a well-formed git url or owner/repo shorthand: {0:?}")]
     InvalidUrl(String),
-    /// 无法从 URL 派生合法 marketplace 名（须显式指定）/ cannot derive a valid marketplace name。
-    #[error("cannot derive a valid marketplace name from {0:?}")]
+    /// 非法 marketplace 名；空串表示未提供显式名且 URL 无法派生合法名 / invalid marketplace name。
+    #[error("invalid marketplace name: {0:?}")]
     InvalidName(String),
     /// marketplace 名已存在（add 拒绝覆盖）/ marketplace name already exists。
     #[error("marketplace name conflict: {0:?} already exists")]
@@ -66,8 +71,8 @@ pub enum GovernanceError {
     /// 未知 marketplace（refresh/remove 目标不存在）/ unknown marketplace。
     #[error("unknown marketplace: {0:?}")]
     UnknownMarketplace(String),
-    /// clone/refresh 失败（stage 降级未落 `known_marketplaces`）/ clone or refresh failed。
-    #[error("clone/refresh failed for {0:?} (see logs)")]
+    /// clone/refresh 失败，载荷为 marketplace 名（stage 降级未落 `known_marketplaces`）/ clone failed。
+    #[error("clone/refresh failed for marketplace {0:?} (see logs)")]
     CloneFailed(String),
     /// plugin 卸载级联失败（remove marketplace 级联期）/ plugin uninstall cascade failed。
     #[error(transparent)]
@@ -179,9 +184,27 @@ pub fn normalize_marketplace_url(raw: &str) -> Option<String> {
 /// 从 git URL 末段派生严格-kebab marketplace 名（去 `.git`、非字母数字折叠为 `-`）/ derive a kebab name。
 #[must_use]
 pub fn default_marketplace_name(url: &str) -> Option<String> {
-    let tail = url.trim_end_matches('/');
-    let seg = tail.rsplit(['/', ':']).next().unwrap_or(tail);
-    let seg = seg.strip_suffix(".git").unwrap_or(seg);
+    let raw = url.trim();
+    let segment = if raw.contains("://") {
+        let parsed = Url::parse(raw).ok()?;
+        if !matches!(parsed.scheme(), "ssh" | "git" | "http" | "https" | "file") {
+            return None;
+        }
+        parsed
+            .path_segments()?
+            .rfind(|part| !part.is_empty())?
+            .to_string()
+    } else {
+        let (_, path) = raw.rsplit_once(':')?;
+        path.split(['?', '#'])
+            .next()
+            .unwrap_or_default()
+            .trim_end_matches('/')
+            .rsplit('/')
+            .find(|part| !part.is_empty())?
+            .to_string()
+    };
+    let seg = segment.strip_suffix(".git").unwrap_or(&segment);
 
     // `re.sub(r"[^a-z0-9]+", "-", seg.lower()).strip("-")`：小写后非 [a-z0-9] 连续段折叠为单 `-`。
     let mut slug = String::new();
@@ -213,18 +236,20 @@ pub struct MarketplaceIdentity {
 /// **纯函数**（不触盘）：CLI 信任门与 [`Computer`](crate::computer::Computer) 级 API 共用，确保两路同一身份语义。
 ///
 /// # Errors
-/// URL 非法 → [`GovernanceError::InvalidUrl`]；无法派生/非法名 → [`GovernanceError::InvalidName`]。
+/// URL 非法 → [`GovernanceError::InvalidUrl`]（安全展示值）；无法派生/非法名 →
+/// [`GovernanceError::InvalidName`]（显式名安全展示值；无显式名时为空串）。
 pub fn resolve_marketplace_identity(
     git_url: &str,
     explicit_name: Option<&str>,
 ) -> Result<MarketplaceIdentity, GovernanceError> {
     let url = normalize_marketplace_url(git_url)
-        .ok_or_else(|| GovernanceError::InvalidUrl(git_url.to_string()))?;
-    let name = explicit_name
-        .map(str::to_string)
-        .or_else(|| default_marketplace_name(&url))
-        .filter(|n| is_valid_marketplace_name(n))
-        .ok_or_else(|| GovernanceError::InvalidName(git_url.to_string()))?;
+        .ok_or_else(|| GovernanceError::InvalidUrl(git_source_for_error(git_url)))?;
+    let name = match explicit_name {
+        Some(name) if is_valid_marketplace_name(name) => name.to_string(),
+        Some(name) => return Err(GovernanceError::InvalidName(redact_git_urls_in_text(name))),
+        None => default_marketplace_name(&url)
+            .ok_or_else(|| GovernanceError::InvalidName(String::new()))?,
+    };
     Ok(MarketplaceIdentity { name, url })
 }
 
@@ -320,7 +345,7 @@ pub(crate) async fn register_or_stage_marketplace(
 
     // 成功判定：stage 失败降级（不抛、返回空 + 不写 known_marketplaces）；据物化记录是否落盘判定。
     if !marketplace_name_taken(home, env, name) {
-        return Err(GovernanceError::CloneFailed(url.clone()));
+        return Err(GovernanceError::CloneFailed(name.clone()));
     }
     Ok(MarketplaceAddOutcome {
         name: name.clone(),
@@ -371,7 +396,7 @@ pub async fn refresh_marketplaces(
     for nm in &names {
         let Some(rec) = mps.marketplaces.get(nm) else {
             rows.push(MarketplaceRefreshRow {
-                name: nm.clone(),
+                name: untrusted_name_for_display(nm),
                 status: RefreshStatus::Missing,
                 skills: 0,
             });
@@ -411,7 +436,7 @@ pub async fn refresh_marketplaces(
             RefreshStatus::Unchanged
         };
         rows.push(MarketplaceRefreshRow {
-            name: nm.clone(),
+            name: untrusted_name_for_display(nm),
             status,
             skills: registered.len(),
         });
@@ -435,11 +460,14 @@ pub async fn remove_marketplace(
     non_plugin_bundle_ids: &std::collections::HashSet<crate::mcp_clients::model::BundleId>,
 ) -> Result<MarketplaceRemoveOutcome, GovernanceError> {
     if !marketplace_name_taken(home, env, name) {
-        return Err(GovernanceError::UnknownMarketplace(name.to_string()));
+        return Err(GovernanceError::UnknownMarketplace(
+            untrusted_name_for_display(name),
+        ));
     }
 
+    let valid_name = is_valid_marketplace_name(name);
     let mut uninstalled: Vec<String> = Vec::new();
-    if !params.keep_plugins {
+    if !params.keep_plugins && valid_name {
         let suffix = format!("@{name}");
         let installed = load_installed_plugins(Some(home), env).account;
         let victims: Vec<String> = installed
@@ -473,12 +501,22 @@ pub async fn remove_marketplace(
     }
 
     let store = make_store(home, env);
-    let pruned = prune_marketplaces(&[name.to_string()], registry, home, &store);
+    let pruned = if valid_name {
+        prune_marketplaces(&[name.to_string()], registry, home, &store)
+    } else {
+        // 手编账本可能含非法 key。它不能安全映射为文件系统路径，也不能原样传入 reconciler tracing；
+        // 仅按精确原始 key 删除账本记录，公开 outcome 使用脱敏展示值，plugin 记录留待显式 GC。
+        let drop_name = name.to_string();
+        store.update_known_marketplaces(&mut |data| {
+            data.marketplaces.shift_remove(&drop_name);
+        });
+        vec![untrusted_name_for_display(name)]
+    };
     Ok(MarketplaceRemoveOutcome {
-        name: name.to_string(),
+        name: untrusted_name_for_display(name),
         pruned,
         uninstalled_plugins: uninstalled,
-        kept_plugins: params.keep_plugins,
+        kept_plugins: params.keep_plugins || !valid_name,
     })
 }
 
@@ -488,7 +526,37 @@ mod tests {
     // `cargo test-ws`（默认特性、无 cli）将无法编译——而这恰会反噬本特性"GUI 无需 cli feature"的目标。
     // marketplace 账本（known_marketplaces.json）落在 `home`（skill_home）内，故 `env = None` 即完全 hermetic。
     use super::*;
+    use std::sync::{Arc, Mutex};
     use tempfile::tempdir;
+    use tracing::instrument::WithSubscriber;
+
+    #[derive(Clone, Default)]
+    struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+    impl CapturedLogs {
+        fn contents(&self) -> String {
+            String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
+        }
+    }
+
+    impl std::io::Write for CapturedLogs {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturedLogs {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
 
     #[test]
     fn normalize_url_passthrough_and_shorthand() {
@@ -513,6 +581,16 @@ mod tests {
             default_marketplace_name("git@github.com:acme/cool-repo.git"),
             Some("cool-repo".to_string())
         );
+        assert_eq!(
+            default_marketplace_name(
+                "https://user:PW_SECRET@example.com/acme/repo.git?token=QUERY#FRAGMENT"
+            ),
+            Some("repo".to_string())
+        );
+        assert_eq!(
+            default_marketplace_name("https://user:PW_SECRET@example.com?token=QUERY#FRAGMENT"),
+            None
+        );
     }
 
     #[test]
@@ -529,6 +607,102 @@ mod tests {
         // 显式名覆盖派生。
         let id2 = resolve_marketplace_identity("acme/skills", Some("custom")).unwrap();
         assert_eq!(id2.name, "custom");
+    }
+
+    #[tokio::test]
+    async fn invalid_explicit_name_never_exposes_git_credentials_or_touches_disk() {
+        const SECRET_URL: &str =
+            "https://cnb:FAKE_TOKEN@example.com/org/repo.git?token=QUERY#token=FRAGMENT";
+        let dir = tempdir().unwrap();
+        let mut registry = SkillRegistry::new();
+        let err = add_marketplace(
+            &mut registry,
+            dir.path(),
+            None,
+            SECRET_URL,
+            AddMarketplaceParams {
+                name: Some("Turingfocus"),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            &err,
+            GovernanceError::InvalidName(name) if name == "Turingfocus"
+        ));
+        let public_forms = format!("{err}\n{err:?}");
+        for secret in ["cnb", "FAKE_TOKEN", "QUERY", "FRAGMENT", SECRET_URL] {
+            assert!(
+                !public_forms.contains(secret),
+                "public error form leaked {secret:?}: {public_forms}"
+            );
+        }
+        assert_eq!(
+            std::fs::read_dir(dir.path()).unwrap().count(),
+            0,
+            "identity validation must fail before any filesystem write"
+        );
+    }
+
+    #[test]
+    fn credentialed_explicit_name_and_pathless_default_are_safe_errors() {
+        let explicit_errors = [
+            "key=https://user:PW_SECRET@example.com/name",
+            "x=https://public.example/a=https://user2:PW_TWO@secret.example/repo.git",
+            "key=用户@example.com:org/repo.git",
+            "x=https://example.com/r.git?token=;QUERY_SECRET",
+            "x=https://example.com/r.git?token=QUERY_QUOTE'LEAK_SECRET",
+            "x=https://alice:PW_ONE'PW_TWO@example.com/repo.git",
+            "x=alice@my_host:org/repo.git",
+            "x=用户@例子.公司:org/repo.git",
+        ]
+        .map(|name| resolve_marketplace_identity("acme/skills", Some(name)).unwrap_err());
+
+        let derived = resolve_marketplace_identity(
+            "https://user:PW_SECRET@example.com?token=QUERY#FRAGMENT",
+            None,
+        )
+        .unwrap_err();
+        assert!(matches!(&derived, GovernanceError::InvalidName(name) if name.is_empty()));
+
+        for error in explicit_errors.into_iter().chain(std::iter::once(derived)) {
+            let rendered = format!("{error}\n{error:?}");
+            for secret in [
+                "user",
+                "PW_SECRET",
+                "QUERY",
+                "FRAGMENT",
+                "user2",
+                "PW_TWO",
+                "用户",
+                "QUERY_SECRET",
+                "QUERY_QUOTE",
+                "LEAK_SECRET",
+                "PW_ONE",
+                "alice",
+            ] {
+                assert!(!rendered.contains(secret), "{rendered}");
+            }
+        }
+    }
+
+    #[test]
+    fn invalid_url_payload_is_safe_for_display_and_debug() {
+        for raw in [
+            "cnb:FAKE_TOKEN@example.com/org/repo.git",
+            "ftp://cnb:FAKE_TOKEN",
+        ] {
+            let err = resolve_marketplace_identity(raw, Some("valid-name")).unwrap_err();
+            assert!(matches!(
+                &err,
+                GovernanceError::InvalidUrl(source) if source == "<redacted-git-source>"
+            ));
+            let public_forms = format!("{err}\n{err:?}");
+            assert!(!public_forms.contains("cnb"));
+            assert!(!public_forms.contains("FAKE_TOKEN"));
+        }
     }
 
     #[tokio::test]
@@ -591,6 +765,83 @@ mod tests {
             .await,
             Err(GovernanceError::UnknownMarketplace(n)) if n == "ghost"
         ));
+    }
+
+    #[tokio::test]
+    async fn unknown_marketplace_and_refresh_target_are_safe_public_values() {
+        let dir = tempdir().unwrap();
+        let mut registry = SkillRegistry::new();
+        let target = "x=https://user:PW_SECRET@example.com/repo.git";
+
+        let error = remove_marketplace(
+            &mut registry,
+            dir.path(),
+            None,
+            target,
+            RemoveMarketplaceParams::default(),
+            &std::collections::HashSet::new(),
+        )
+        .await
+        .unwrap_err();
+        let rows = refresh_marketplaces(&mut registry, dir.path(), None, target).await;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].status, RefreshStatus::Missing);
+
+        for rendered in [
+            format!("{error}\n{error:?}"),
+            format!("{:?}\n{}", rows[0], rows[0].name),
+        ] {
+            for secret in ["user", "PW_SECRET"] {
+                assert!(!rendered.contains(secret), "{rendered}");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn remove_hand_edited_invalid_key_deletes_exact_record_without_log_leak() {
+        let dir = tempdir().unwrap();
+        let home = dir.path();
+        let raw_name = "x=https://alice:PW_REMOVE@example.com/repo.git";
+        update_known_marketplaces(
+            |data| {
+                data.account.marketplaces.insert(
+                    raw_name.to_string(),
+                    KnownMarketplaceEntry {
+                        source: json!({"type": "git", "url": "https://example.com/repo.git"}),
+                        extra: Map::new(),
+                    },
+                );
+            },
+            Some(home),
+            None,
+        )
+        .unwrap();
+
+        let logs = CapturedLogs::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .without_time()
+            .with_writer(logs.clone())
+            .finish();
+        let mut registry = SkillRegistry::new();
+        let outcome = remove_marketplace(
+            &mut registry,
+            home,
+            None,
+            raw_name,
+            RemoveMarketplaceParams::default(),
+            &std::collections::HashSet::new(),
+        )
+        .with_subscriber(subscriber)
+        .await
+        .unwrap();
+
+        assert!(!marketplace_name_taken(home, None, raw_name));
+        assert!(outcome.kept_plugins, "非法 key 不得映射到级联删除路径");
+        let rendered = format!("{outcome:?}\n{}", logs.contents());
+        for secret in ["alice", "PW_REMOVE"] {
+            assert!(!rendered.contains(secret), "{rendered}");
+        }
     }
 
     #[tokio::test]
@@ -861,7 +1112,7 @@ mod tests {
     fn resolve_identity_dotgit_only_tail_is_invalid_name() {
         assert!(matches!(
             resolve_marketplace_identity("https://example.com/.git", None),
-            Err(GovernanceError::InvalidName(_))
+            Err(GovernanceError::InvalidName(name)) if name.is_empty()
         ));
     }
 
@@ -884,7 +1135,10 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(matches!(err, GovernanceError::CloneFailed(_)));
+        assert!(matches!(
+            err,
+            GovernanceError::CloneFailed(name) if name == "acme"
+        ));
         // 降级铁律：未落 known_marketplaces。
         assert!(!marketplace_name_taken(home, None, "acme"));
     }

--- a/crates/smcp-computer/src/settings/mod.rs
+++ b/crates/smcp-computer/src/settings/mod.rs
@@ -16,6 +16,7 @@ pub mod mcp_config;
 pub mod policy;
 pub mod reconciler;
 pub mod recovery;
+pub(crate) mod redaction;
 pub mod schema;
 pub mod scope;
 pub mod store;

--- a/crates/smcp-computer/src/settings/policy.rs
+++ b/crates/smcp-computer/src/settings/policy.rs
@@ -31,7 +31,7 @@
 //! [`resolve_settings`](crate::settings::scope::resolve_settings) 按 POLICY scope 统一执行（policy-only 字段
 //! `allowedMcpServers` / `deniedMcpServers` 只在该层生效）。
 //!
-//! 条件编译 / Conditional compilation：macOS plist（[`plist`] crate）与 Windows 注册表（`winreg` crate）读取器
+//! 条件编译 / Conditional compilation：macOS plist（`plist` crate）与 Windows 注册表（`winreg` crate）读取器
 //! 按 `#[cfg(target_os = ...)]` 编译真实实现，其它平台为 `None` stub —— 跨平台构建不破坏，平台依赖经
 //! `[target.'cfg(...)'.dependencies]` off-platform 零成本。Windows 路径 best-effort、**无 CI lane 验证**（与
 //! Python `policy.py` win32 同姿态）。

--- a/crates/smcp-computer/src/settings/redaction.rs
+++ b/crates/smcp-computer/src/settings/redaction.rs
@@ -1,0 +1,320 @@
+/*!
+* 文件名: redaction.rs
+* 作者: JQQ
+* 创建日期: 2026/07/23
+* 最后修改日期: 2026/07/23
+* 版权: 2023 JQQ. All rights reserved.
+* 依赖: url
+* 描述: settings / Marketplace 公开边界共用的 URL 凭据脱敏。
+*       Shared URL credential redaction for settings and Marketplace public boundaries.
+*/
+
+//! URL 凭据脱敏纯函数 / Pure URL credential-redaction helpers。
+//!
+//! URL 的 userinfo、query、fragment 都可能承载凭据。公开错误不得保存这些原始片段，因为派生
+//! `Debug` / `Display` 会把枚举字段直接带入日志；配置导出则只替换已确认的 userinfo 面，保留其余 URL。
+
+use url::Url;
+
+/// 无法安全呈现的 Git 来源占位符 / placeholder for a Git source that cannot be shown safely.
+pub(crate) const REDACTED_GIT_SOURCE: &str = "<redacted-git-source>";
+
+/// 若 `url` 的 authority 段含非空 userinfo，返回以 `replacement` 替换 userinfo 后的新串。
+///
+/// 只识别 `scheme://authority` 形态；authority 终止于首个 `/`、`?` 或 `#`。调用方决定替换哨兵，
+/// 从而让配置导出保留显式 `${REDACTED}`，错误边界使用无凭据的安全形态。
+pub(crate) fn url_with_redacted_userinfo(url: &str, replacement: &str) -> Option<String> {
+    let after_scheme = url.find("://")? + 3;
+    let authority_end = url[after_scheme..]
+        .find(['/', '?', '#'])
+        .map(|i| after_scheme + i)
+        .unwrap_or(url.len());
+    let at_rel = url[after_scheme..authority_end].rfind('@')?;
+    let at = after_scheme + at_rel;
+    if at <= after_scheme {
+        return None;
+    }
+    let suffix_start = if replacement.is_empty() { at + 1 } else { at };
+    Some(format!(
+        "{}{}{}",
+        &url[..after_scheme],
+        replacement,
+        &url[suffix_start..]
+    ))
+}
+
+/// 把任意 Git URL 规整为可进入 CLI / 日志 / 公开错误的安全展示值。
+///
+/// 仅在 [`Url::parse`] 严格成功后保留 scheme/host/path；完整 userinfo、query、fragment 一律移除。
+/// scp-like 或畸形输入无法可靠划分 authority，故完全隐藏。
+pub(crate) fn git_url_for_display(raw: &str) -> String {
+    let Ok(mut parsed) = Url::parse(raw.trim()) else {
+        return REDACTED_GIT_SOURCE.to_string();
+    };
+    if !matches!(parsed.scheme(), "ssh" | "git" | "http" | "https" | "file") {
+        return REDACTED_GIT_SOURCE.to_string();
+    }
+
+    if !parsed.username().is_empty() && parsed.set_username("").is_err() {
+        return REDACTED_GIT_SOURCE.to_string();
+    }
+    if parsed.password().is_some() && parsed.set_password(None).is_err() {
+        return REDACTED_GIT_SOURCE.to_string();
+    }
+    parsed.set_query(None);
+    parsed.set_fragment(None);
+    parsed.to_string()
+}
+
+/// 非法 Git 来源的公开错误载荷与 CLI 展示共用同一严格安全边界。
+pub(crate) fn git_source_for_error(raw: &str) -> String {
+    git_url_for_display(raw)
+}
+
+fn source_end_boundary(ch: char) -> bool {
+    ch.is_whitespace()
+}
+
+fn wrapper_suffix_boundary(ch: char) -> bool {
+    matches!(
+        ch,
+        '\'' | '"' | '`' | ':' | ';' | ',' | '.' | '!' | '?' | ')' | ']' | '}'
+    )
+}
+
+/// 若 scheme 前紧邻引号包装符，只把**最后一个**且其后全为外层标点的同类引号视为闭合符。
+///
+/// URL userinfo/query 自身允许单引号；按第一个引号截断会泄露后半凭据。无法证明是外层闭合符时，
+/// 整个非空白 token 都留给 URL sanitizer fail-closed 处理。
+fn split_outer_wrapper<'a>(prefix: &str, candidate: &'a str) -> (&'a str, &'a str) {
+    let Some(wrapper) = prefix
+        .chars()
+        .next_back()
+        .filter(|ch| matches!(ch, '\'' | '"' | '`'))
+    else {
+        return (candidate, "");
+    };
+    let Some((close, _)) = candidate.char_indices().rev().find(|(index, ch)| {
+        *ch == wrapper && candidate[*index..].chars().all(wrapper_suffix_boundary)
+    }) else {
+        return (candidate, "");
+    };
+    (&candidate[..close], &candidate[close..])
+}
+
+fn redact_scp_like_sources(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(at) = rest.find('@') {
+        let start = rest[..at].rfind(source_end_boundary).map_or(0, |index| {
+            index + rest[index..].chars().next().map_or(0, char::len_utf8)
+        });
+
+        let token_end = rest[at + 1..]
+            .find(source_end_boundary)
+            .map_or(rest.len(), |index| at + 1 + index);
+        let userinfo = &rest[start..at];
+        let destination = &rest[at + 1..token_end];
+        let colon_rel = destination.find(':');
+        let ssh_possessive = destination.contains("'s");
+        if start == at
+            || destination.is_empty()
+            || colon_rel == Some(0)
+            || (colon_rel.is_none() && !userinfo.contains(':') && !ssh_possessive)
+        {
+            let consumed = at + 1;
+            out.push_str(&rest[..consumed]);
+            rest = &rest[consumed..];
+            continue;
+        }
+
+        let path_end = token_end;
+        if start < at {
+            out.push_str(&rest[..start]);
+            out.push_str(REDACTED_GIT_SOURCE);
+            rest = &rest[path_end..];
+        } else {
+            let consumed = at + 1;
+            out.push_str(&rest[..consumed]);
+            rest = &rest[consumed..];
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+fn is_scheme_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'-' | b'.')
+}
+
+/// 脱敏散文中的完整 Git source token；用于 Git stderr、公开错误等上游诊断文本。
+///
+/// 任何 `scheme://` 形态都按不可信来源处理：受支持且可解析的 scheme 仅保留
+/// scheme/host/path，畸形或不受支持的 scheme 完全隐藏。scp-like source 无法可靠拆分凭据，
+/// 同样完全隐藏。
+pub(crate) fn redact_git_urls_in_text(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(marker) = rest.find("://") {
+        let mut scheme_start = marker;
+        while scheme_start > 0 && is_scheme_byte(rest.as_bytes()[scheme_start - 1]) {
+            scheme_start -= 1;
+        }
+        while scheme_start < marker && !rest.as_bytes()[scheme_start].is_ascii_alphabetic() {
+            scheme_start += 1;
+        }
+        let scheme = &rest[scheme_start..marker];
+        if scheme.is_empty() || !scheme.bytes().all(is_scheme_byte) {
+            let consumed = marker + 3;
+            out.push_str(&rest[..consumed]);
+            rest = &rest[consumed..];
+            continue;
+        }
+
+        out.push_str(&rest[..scheme_start]);
+        let token = &rest[scheme_start..];
+        let end = token.find(source_end_boundary).unwrap_or(token.len());
+        let candidate = &token[..end];
+        let (candidate, wrapper_suffix) = split_outer_wrapper(&rest[..scheme_start], candidate);
+        let first_marker_end = marker - scheme_start + 3;
+        if candidate[first_marker_end..].contains("://") {
+            out.push_str(REDACTED_GIT_SOURCE);
+        } else {
+            out.push_str(&git_url_for_display(candidate));
+        }
+        out.push_str(wrapper_suffix);
+        rest = &token[end..];
+    }
+    out.push_str(rest);
+    redact_scp_like_sources(&out)
+}
+
+/// 未验证的 marketplace name/target 的公开展示边界。
+///
+/// 合法 kebab 名不含 URL 结构，调用本函数后逐字保持；恶意或畸形输入若嵌入 Git source，则按与公开错误
+/// 相同的 fail-closed 规则脱敏。
+pub(crate) fn untrusted_name_for_display(raw: &str) -> String {
+    redact_git_urls_in_text(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_complete_userinfo_and_preserves_destination() {
+        assert_eq!(
+            url_with_redacted_userinfo(
+                "https://alice:s3cr3t@[::1]:8080/org/repo.git",
+                "${REDACTED}"
+            ),
+            Some("https://${REDACTED}@[::1]:8080/org/repo.git".to_string())
+        );
+    }
+
+    #[test]
+    fn public_error_source_drops_credentials_query_and_fragment() {
+        let got = git_url_for_display(
+            "https://cnb:FAKE_TOKEN@example.com/org/repo.git?token=QUERY#token=FRAGMENT",
+        );
+        assert_eq!(got, "https://example.com/org/repo.git");
+        for secret in ["cnb", "FAKE_TOKEN", "QUERY", "FRAGMENT"] {
+            assert!(!got.contains(secret));
+        }
+    }
+
+    #[test]
+    fn opaque_invalid_source_is_not_echoed() {
+        for source in [
+            "cnb:FAKE_TOKEN@example.com/org/repo.git",
+            "cnb:FAKE_TOKEN@https://example.com/org/repo.git",
+            "ftp://cnb:FAKE_TOKEN",
+        ] {
+            assert_eq!(git_url_for_display(source), REDACTED_GIT_SOURCE);
+        }
+    }
+
+    #[test]
+    fn redacts_git_url_embedded_in_diagnostic_text() {
+        let got = redact_git_urls_in_text(
+            "fatal: unable to access 'https://cnb:FAKE_TOKEN@example.com/repo.git?token=QUERY#FRAGMENT/': failed",
+        );
+        assert_eq!(
+            got,
+            "fatal: unable to access 'https://example.com/repo.git': failed"
+        );
+    }
+
+    #[test]
+    fn hides_unsupported_malformed_and_scp_like_sources_in_text() {
+        for text in [
+            "bad ftp://cnb:FAKE_TOKEN@example.com/repo.git source",
+            "bad https://cnb:FAKE_TOKEN source",
+            "bad git@example.com:org/repo.git source",
+        ] {
+            let got = redact_git_urls_in_text(text);
+            assert!(got.contains(REDACTED_GIT_SOURCE), "{got}");
+            for secret in ["cnb", "FAKE_TOKEN", "git@example.com"] {
+                assert!(!got.contains(secret), "{got}");
+            }
+        }
+    }
+
+    #[test]
+    fn finds_sources_after_arbitrary_prefixes_and_multiple_delimiters() {
+        let got = redact_git_urls_in_text(
+            "key=https://user:PW_ONE@example.com/a.git;\
+             prefix:https://user:PW_TWO@example.com/b.git|\
+             path/ssh://user:PW_THREE@example.com/c.git;\
+             source=git@example.com:org/repo.git",
+        );
+        for secret in ["user", "PW_ONE", "PW_TWO", "PW_THREE", "git@example.com"] {
+            assert!(!got.contains(secret), "{got}");
+        }
+        assert!(got.contains(REDACTED_GIT_SOURCE), "{got}");
+    }
+
+    #[test]
+    fn nested_urls_and_unicode_scp_like_are_hidden_fail_closed() {
+        for text in [
+            "x=https://public.example/a=https://user2:PW_TWO@secret.example/repo.git",
+            "key=用户@example.com:org/repo.git",
+            "key=alice@my_host:org/repo.git",
+            "key=用户@例子.公司:org/repo.git",
+            "ssh: alice@my_host: Permission denied (publickey).",
+            "ssh: 用户@例子.公司: Permission denied (publickey).",
+            "ssh: alice@my_host's password:",
+            "ssh: 用户@例子.公司's password:",
+            "path=/tmp/x=https:/alice:PW_PATH@example.com/repo.git missing",
+            "x=https://example.com/r.git?token=;QUERY_SECRET",
+            "x=https://example.com/r.git?token=,COMMA_SECRET",
+            "x=https://example.com/r.git?token=QUERY_QUOTE'LEAK_SECRET",
+            "x=https://alice:PW_ONE'PW_TWO@example.com/repo.git",
+        ] {
+            let got = redact_git_urls_in_text(text);
+            for secret in [
+                "user2",
+                "PW_TWO",
+                "用户",
+                "alice",
+                "PW_PATH",
+                "QUERY_SECRET",
+                "COMMA_SECRET",
+                "QUERY_QUOTE",
+                "LEAK_SECRET",
+                "PW_ONE",
+                "PW_TWO",
+            ] {
+                assert!(!got.contains(secret), "{got}");
+            }
+        }
+    }
+
+    #[test]
+    fn ordinary_marketplace_name_is_preserved_for_display() {
+        assert_eq!(
+            untrusted_name_for_display("lowercase-kebab"),
+            "lowercase-kebab"
+        );
+    }
+}

--- a/crates/smcp-computer/src/skills/sources.rs
+++ b/crates/smcp-computer/src/skills/sources.rs
@@ -28,6 +28,7 @@
 use serde_json::{Map, Value};
 
 use crate::settings::is_valid_git_url;
+use crate::settings::redaction::redact_git_urls_in_text;
 
 // ---------------------------------------------------------------------------
 // 常量 / Constants
@@ -57,9 +58,10 @@ pub struct SkillSourceError {
 
 impl SkillSourceError {
     fn new(raw: &str, reason: impl Into<String>) -> Self {
+        let reason = reason.into();
         Self {
-            raw: raw.to_string(),
-            reason: reason.into(),
+            raw: redact_git_urls_in_text(raw),
+            reason: redact_git_urls_in_text(&reason),
         }
     }
 }
@@ -577,5 +579,101 @@ mod tests {
         assert!(marketplace_clone_url(&json!({"type": "github", "url": "owner/repo"})).is_err());
         assert!(marketplace_clone_url(&json!({"type": "git", "url": "bogus"})).is_err());
         assert!(marketplace_clone_url(&json!("https://h/r.git")).is_err());
+    }
+
+    #[test]
+    fn public_source_errors_never_echo_url_credentials() {
+        let cases = [
+            resolve_plugin_source(
+                &json!({
+                    "source": "url",
+                    "url": "https://cnb:FAKE_TOKEN@example.com/org/repo.git?token=QUERY#FRAGMENT",
+                    "sha": "bad"
+                }),
+                DEFAULT_PLUGIN_ROOT,
+            )
+            .unwrap_err(),
+            resolve_plugin_source(
+                &json!({
+                    "source": "url",
+                    "url": "ftp://cnb:FAKE_TOKEN@example.com/org/repo.git"
+                }),
+                DEFAULT_PLUGIN_ROOT,
+            )
+            .unwrap_err(),
+            resolve_plugin_source(
+                &json!({
+                    "source": "github",
+                    "repo": "git@example.com:org/repo.git"
+                }),
+                DEFAULT_PLUGIN_ROOT,
+            )
+            .unwrap_err(),
+            marketplace_clone_url(&json!({
+                "type": "git",
+                "url": "ftp://cnb:FAKE_TOKEN@example.com/org/repo.git"
+            }))
+            .unwrap_err(),
+            resolve_plugin_source(
+                &json!("key=https://cnb:FAKE_TOKEN@example.com/org/repo.git"),
+                DEFAULT_PLUGIN_ROOT,
+            )
+            .unwrap_err(),
+            resolve_plugin_source(
+                &json!("key=git@example.com:org/repo.git"),
+                DEFAULT_PLUGIN_ROOT,
+            )
+            .unwrap_err(),
+            resolve_plugin_source(
+                &json!("x=https://public.example/a=https://user2:PW_TWO@secret.example/repo.git"),
+                DEFAULT_PLUGIN_ROOT,
+            )
+            .unwrap_err(),
+            resolve_plugin_source(
+                &json!("key=用户@example.com:org/repo.git"),
+                DEFAULT_PLUGIN_ROOT,
+            )
+            .unwrap_err(),
+            resolve_plugin_source(
+                &json!("x=https://example.com/r.git?token=;QUERY_SECRET"),
+                DEFAULT_PLUGIN_ROOT,
+            )
+            .unwrap_err(),
+            resolve_plugin_source(
+                &json!("x=https://example.com/r.git?token=QUERY_QUOTE'LEAK_SECRET"),
+                DEFAULT_PLUGIN_ROOT,
+            )
+            .unwrap_err(),
+            resolve_plugin_source(
+                &json!("x=https://alice:PW_ONE'PW_TWO@example.com/repo.git"),
+                DEFAULT_PLUGIN_ROOT,
+            )
+            .unwrap_err(),
+            resolve_plugin_source(&json!("x=alice@my_host:org/repo.git"), DEFAULT_PLUGIN_ROOT)
+                .unwrap_err(),
+            resolve_plugin_source(&json!("x=用户@例子.公司:org/repo.git"), DEFAULT_PLUGIN_ROOT)
+                .unwrap_err(),
+        ];
+
+        for error in cases {
+            let rendered = format!("{error}\n{error:?}\n{}\n{}", error.raw, error.reason);
+            for secret in [
+                "cnb",
+                "FAKE_TOKEN",
+                "QUERY",
+                "FRAGMENT",
+                "git@example.com",
+                "user2",
+                "PW_TWO",
+                "用户",
+                "QUERY_SECRET",
+                "QUERY_QUOTE",
+                "LEAK_SECRET",
+                "PW_ONE",
+                "alice",
+            ] {
+                assert!(!rendered.contains(secret), "{rendered}");
+            }
+        }
     }
 }

--- a/crates/smcp-computer/src/skills/staging.rs
+++ b/crates/smcp-computer/src/skills/staging.rs
@@ -48,6 +48,9 @@ use tokio::sync::RwLock;
 use smcp::utils::path::{is_within, normalize_lexical};
 use smcp::A2CSkillRef;
 
+use crate::settings::redaction::{
+    git_url_for_display, redact_git_urls_in_text, untrusted_name_for_display,
+};
 use crate::settings::{is_valid_marketplace_name, EnvMap};
 use crate::skills::frontmatter::parse_skill_frontmatter;
 use crate::skills::home::{
@@ -524,6 +527,24 @@ fn apply_git_env(cmd: &mut tokio::process::Command, env: Option<&EnvMap>) {
     }
 }
 
+/// Git stderr 可能回显 clone URL；按本次命令中已知 URL 参数逐一替换为安全展示值。
+fn sanitize_git_stderr(args: &[&str], stderr: &str) -> String {
+    let known_args_redacted = args
+        .iter()
+        .filter(|arg| arg.contains("://") || SSH_SCP_LIKE_RE.is_match(arg))
+        .fold(stderr.to_string(), |sanitized, raw_url| {
+            let display = git_url_for_display(raw_url);
+            let mut sanitized = sanitized.replace(*raw_url, &display);
+            if SSH_SCP_LIKE_RE.is_match(raw_url) {
+                if let Some((endpoint, _)) = raw_url.split_once(':') {
+                    sanitized = sanitized.replace(endpoint, &display);
+                }
+            }
+            sanitized
+        });
+    redact_git_urls_in_text(&known_args_redacted)
+}
+
 /// 执行 `git <args>` 并返回 stdout（非零退出 / 超时 → 错误）/ Run `git`, capture stdout。
 async fn run_git(
     args: &[&str],
@@ -551,10 +572,11 @@ async fn run_git(
         }
     };
     if !output.status.success() {
-        let err = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let err = sanitize_git_stderr(args, stderr.trim());
         return Err(SkillStagingError::new(format!(
             "git {} failed (rc={:?}): {err}",
-            args.join(" "),
+            args.first().copied().unwrap_or("operation"),
             output.status.code()
         )));
     }
@@ -602,7 +624,12 @@ async fn git_clone_with_fallback(
             let https = ssh_to_https(url);
             match https {
                 Some(h) if h != url => {
-                    tracing::warn!(url, error = %first, https = %h, "git clone failed; retrying via HTTPS");
+                    tracing::warn!(
+                        url = %git_url_for_display(url),
+                        error = %first,
+                        https = %git_url_for_display(&h),
+                        "git clone failed; retrying via HTTPS"
+                    );
                     let _ = std::fs::remove_dir_all(dest);
                     let mut retry: Vec<String> = vec!["clone".to_string()];
                     retry.extend(clone_args.iter().cloned());
@@ -728,7 +755,10 @@ async fn git_head_sha(dest: &Path, timeout: Duration, env: Option<&EnvMap>) -> O
 /// plugin 条目 ID = entry.name / The plugin entry name。
 fn entry_plugin_name(entry: &Map<String, Value>) -> Result<String, SkillStagingError> {
     match entry.get("name").and_then(Value::as_str) {
-        Some(n) if !n.trim().is_empty() => Ok(n.trim().to_string()),
+        Some(n) if is_valid_marketplace_name(n.trim()) => Ok(n.trim().to_string()),
+        Some(_) => Err(SkillStagingError::new(
+            "plugin entry 'name' must be lowercase kebab-case (1-64 characters)",
+        )),
         _ => Err(SkillStagingError::new(
             "plugin entry missing required 'name'",
         )),
@@ -903,10 +933,9 @@ pub(crate) async fn locate_plugin_root(
     };
 
     if !plugin_root.is_dir() {
-        return Err(SkillStagingError::new(format!(
-            "plugin root not found after resolve: {}",
-            plugin_root.display()
-        )));
+        return Err(SkillStagingError::new(
+            "plugin root not found after source resolution",
+        ));
     }
     Ok((plugin_root, version_fallback))
 }
@@ -998,7 +1027,7 @@ pub async fn stage_marketplace_skills(
     // 防御纵深：name 直接作路径段，仅接受严格 kebab marketplace 名（拒 `..` / `/` 穿越）。
     if !is_valid_marketplace_name(name) {
         tracing::error!(
-            marketplace = name,
+            marketplace = %untrusted_name_for_display(name),
             "marketplace name invalid (strict-kebab 1-64), skipped"
         );
         return registered;
@@ -1006,8 +1035,8 @@ pub async fn stage_marketplace_skills(
 
     let url = match marketplace_clone_url(source) {
         Ok(u) => u,
-        Err(e) => {
-            tracing::error!(marketplace = name, error = %e, "invalid marketplace source, skipped");
+        Err(_) => {
+            tracing::error!(marketplace = name, "invalid marketplace source, skipped");
             return registered;
         }
     };
@@ -1425,7 +1454,37 @@ pub async fn stage_mcp_skills(
 mod tests {
     use super::*;
     use std::fs;
+    use std::sync::{Arc, Mutex};
     use tempfile::TempDir;
+    use tracing::instrument::WithSubscriber;
+
+    #[derive(Clone, Default)]
+    struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+    impl CapturedLogs {
+        fn contents(&self) -> String {
+            String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
+        }
+    }
+
+    impl std::io::Write for CapturedLogs {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CapturedLogs {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
 
     // ---- 安全解包 / safe extraction ----
     #[test]
@@ -1508,6 +1567,59 @@ mod tests {
         );
         assert_eq!(ssh_to_https("https://github.com/owner/repo.git"), None);
         assert_eq!(ssh_to_https("file:///tmp/repo"), None);
+    }
+
+    #[tokio::test]
+    async fn test_git_failure_diagnostics_redact_url_credentials() {
+        const SECRET_URL: &str = "https://cnb:FAKE_TOKEN@127.0.0.1:1/repo.git?token=QUERY#FRAGMENT";
+        let tmp = TempDir::new().unwrap();
+        let dest = tmp.path().join("clone");
+        let dest_s = dest.to_string_lossy().into_owned();
+        let err = run_git(
+            &["clone", "--", SECRET_URL, &dest_s],
+            Duration::from_secs(10),
+            None,
+        )
+        .await
+        .unwrap_err();
+        let public_forms = format!("{err}\n{err:?}");
+        assert!(public_forms.contains("git clone failed"));
+        for secret in ["cnb", "FAKE_TOKEN", "QUERY", "FRAGMENT", SECRET_URL] {
+            assert!(
+                !public_forms.contains(secret),
+                "git diagnostic leaked {secret:?}: {public_forms}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_git_stderr_redacts_abbreviated_scp_endpoint() {
+        for (source, stderr, secrets) in [
+            (
+                "alice@my_host:org/repo.git",
+                "alice@my_host: Permission denied (publickey).",
+                ["alice", "unused"],
+            ),
+            (
+                "用户@例子.公司:org/repo.git",
+                "用户@例子.公司: Permission denied (publickey).",
+                ["用户", "例子.公司"],
+            ),
+            (
+                "alice@my_host:org/repo.git",
+                "alice@my_host's password:",
+                ["alice", "my_host"],
+            ),
+        ] {
+            let rendered = sanitize_git_stderr(&["clone", "--", source], stderr);
+            assert!(
+                rendered.contains(crate::settings::redaction::REDACTED_GIT_SOURCE),
+                "{rendered}"
+            );
+            for secret in secrets {
+                assert!(!rendered.contains(secret), "{rendered}");
+            }
+        }
     }
 
     // ---- ref 合成 / ref construction ----
@@ -1643,6 +1755,98 @@ mod tests {
         assert_eq!(r.source, "marketplace:acme");
         assert_eq!(r.description, "review code");
         assert!(r.uri.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_plugin_source_error_log_redacts_url_credentials() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        fs::create_dir_all(repo.join(".tfrobot-plugin")).unwrap();
+        fs::write(
+            repo.join(".tfrobot-plugin/marketplace.json"),
+            r#"{"plugins":[
+                {"name":"audit","source":{"source":"url","url":"ftp://cnb:FAKE_TOKEN@example.com/org/repo.git?token=QUERY#FRAGMENT"}},
+                {"name":"prefix","source":"key=https://user:PW_PREFIX@example.com/org/repo.git"},
+                {"name":"scp","source":"key=git@example.com:org/repo.git"},
+                {"name":"x=https://alice:PW_NAME@example.com/repo.git","source":{"source":"url","url":"bogus"}},
+                {"name":"local-leak","source":"./x=https://alice:PW_LOCAL@example.com/repo.git"}
+            ]}"#,
+        )
+        .unwrap();
+        git(&["init", "-q"], &repo);
+        git(&["add", "-A"], &repo);
+        git(&["commit", "-qm", "init"], &repo);
+
+        let home = tmp.path().join("home");
+        fs::create_dir_all(&home).unwrap();
+        let source =
+            serde_json::json!({"type": "git", "url": format!("file://{}", repo.display())});
+        let logs = CapturedLogs::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .without_time()
+            .with_target(false)
+            .with_writer(logs.clone())
+            .finish();
+        let mut registry = SkillRegistry::new();
+        let names = stage_marketplace_skills(
+            "acme",
+            &source,
+            &mut registry,
+            &home,
+            MarketplaceStageOptions::default(),
+        )
+        .with_subscriber(subscriber)
+        .await;
+
+        assert!(names.is_empty());
+        let rendered = logs.contents();
+        assert!(
+            rendered.contains("plugin staging failed, skipped"),
+            "{rendered}"
+        );
+        for secret in [
+            "cnb",
+            "FAKE_TOKEN",
+            "QUERY",
+            "FRAGMENT",
+            "user",
+            "PW_PREFIX",
+            "PW_NAME",
+            "PW_LOCAL",
+            "git@example.com",
+        ] {
+            assert!(!rendered.contains(secret), "{rendered}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_invalid_marketplace_name_log_redacts_embedded_credentials() {
+        let tmp = TempDir::new().unwrap();
+        let logs = CapturedLogs::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .without_time()
+            .with_target(false)
+            .with_writer(logs.clone())
+            .finish();
+        let mut registry = SkillRegistry::new();
+        let names = stage_marketplace_skills(
+            "x=https://public.example/a=https://user2:PW_TWO@secret.example/repo.git",
+            &serde_json::json!({"type": "git", "url": "https://example.com/repo.git"}),
+            &mut registry,
+            tmp.path(),
+            MarketplaceStageOptions::default(),
+        )
+        .with_subscriber(subscriber)
+        .await;
+
+        assert!(names.is_empty());
+        let rendered = logs.contents();
+        assert!(rendered.contains("marketplace name invalid"), "{rendered}");
+        for secret in ["user2", "PW_TWO"] {
+            assert!(!rendered.contains(secret), "{rendered}");
+        }
     }
 
     // ---- mcp 源物化（fake manager，mounted 模式）/ mcp materialization with a fake manager ----


### PR DESCRIPTION
## Summary

- centralize fail-closed Git source redaction for public errors, CLI output, logs, and governance DTOs
- report the invalid explicit marketplace name safely instead of binding `InvalidName` to the credentialed source URL
- harden derived marketplace identities, hand-edited ledgers, manifest/plugin paths, and Git stderr handling
- add adversarial regression coverage for URL userinfo/query/fragment, nested/malformed URLs, scp/OpenSSH forms, Unicode hosts, punctuation, and quote boundaries

## Validation

- `cargo test-computer` (909 unit tests plus integration and doc tests)
- `cargo clippy-workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc-check`
- `cargo fmt --all -- --check`
- `git diff --check`
- independent code review: **APPROVE** (`BLOCK=0`, `WARN=0`)

Closes #154